### PR TITLE
Don't require people to create a `diva` directory next to the apworld anymore

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -20,6 +20,10 @@ def select_json_file():
 
 def load_all_modded_json_files(directory: str) -> List[Dict[str, Any]]:
     """Loads all JSON files from the given directory and returns their content along with filenames"""
+    if not os.path.isdir(directory):
+        print(f"Warning: {directory} is not a directory or doesn't exist, could not load modded json from it")
+        return []
+
     modded_data = []
     for filename in os.listdir(directory):
         if filename.endswith(".json"):


### PR DESCRIPTION
Instead, print a warning that will help people understand why their modded content might not be loaded.

This makes it easier for people to integrate it in their apworld library, by not having to do an extra step manually when it's not required most of the time.