### PR TITLE
Duplicate song / Filler toggle

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -186,6 +186,9 @@ class MegaMixContext(CommonContext):
                     if item_name == "Leek":
                         self.leeks_obtained += 1
                         self.check_goal()
+                    elif item_name == "SAFE":
+                        # Maybe move static items out of MegaMixCollection instead of hard coding?
+                        pass
                     else:
                         if self.is_item_in_modded_data(item_name):
                             song_unlock(self.path, item_name, self.modData, False, True, logger)

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -22,9 +22,16 @@ class MegaMixCollections:
 
     song_items: Dict[str, SongData] = {}
     song_locations: Dict[str, int] = {}
+    
+    filler_item_names: Dict[str, int] = {
+        "SAFE": STARTING_CODE + 1,
+    }
+    filler_item_weights: Dict[str, int] = {
+        "SAFE": 1,
+    }
 
     def __init__(self) -> None:
-        self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.song_items)
+        self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.filler_item_names, self.song_items)
         self.location_names_to_id = ChainMap(self.song_locations)
 
         item_id_index = self.STARTING_CODE + 50

--- a/Options.py
+++ b/Options.py
@@ -31,6 +31,15 @@ class UsingModdedSongs(Toggle):
     display_name = "Using Modded Songs"
 
 
+class DuplicateSongs(Toggle):
+    """
+    Whether duplicate songs should appear instead of regular filler.
+    Duplicate songs are considered Useful and thus out of logic.
+    """
+    default = True
+    display_name = "Duplicate Songs as Filler"
+
+
 class DifficultyMode(Choice):
     """Ensures that at all songs have this difficulty available.
     - Any: Song can be beaten on any difficulty
@@ -207,6 +216,7 @@ class ExcludeSongs(ItemSet):
 class MegaMixOptions(PerGameCommonOptions):
     allow_megamix_dlc_songs: AllowMegaMixDLCSongs
     using_modded_songs: UsingModdedSongs
+    duplicate_songs: DuplicateSongs
     starting_song_count: StartingSongs
     additional_song_count: AdditionalSongs
     song_difficulty_mode: DifficultyMode

--- a/__init__.py
+++ b/__init__.py
@@ -188,18 +188,23 @@ class MegaMixWorld(World):
         if items_left <= 0:
             return
 
+        # Unlike MD this is all or nothing. A configurable percentage could be added.
+        if not self.options.duplicate_songs:
+            filler_count = items_left
+            items_left -= filler_count
+
+            for _ in range(0, filler_count):
+                filler_item = self.create_item(self.random.choices(self.filler_item_names, self.filler_item_weights)[0])
+                self.multiworld.itempool.append(filler_item)
+
         # All remaining spots are filled with duplicate songs. Duplicates are set to useful instead of progression
         # to cut down on the number of progression items that Mega mix puts into the pool.
 
         # This is for the extraordinary case of needing to fill a lot of items.
         while items_left > len(song_keys_in_pool):
             for key in song_keys_in_pool:
-                if self.options.duplicate_songs:
-                    item = self.create_item(key)
-                    item.classification = ItemClassification.useful
-                else:
-                    item = self.create_item(self.random.choices(self.filler_item_names, self.filler_item_weights)[0])
-
+                item = self.create_item(key)
+                item.classification = ItemClassification.useful
                 self.multiworld.itempool.append(item)
 
             items_left -= len(song_keys_in_pool)

--- a/__init__.py
+++ b/__init__.py
@@ -54,6 +54,8 @@ class MegaMixWorld(World):
 
     # Necessary Data
     mm_collection = MegaMixCollections()
+    filler_item_names = list(mm_collection.filler_item_weights.keys())
+    filler_item_weights = list(mm_collection.filler_item_weights.values())
 
     item_name_to_id = {name: code for name, code in mm_collection.item_names_to_id.items()}
     location_name_to_id = {name: code for name, code in mm_collection.location_names_to_id.items()}
@@ -196,11 +198,7 @@ class MegaMixWorld(World):
                     item = self.create_item(key)
                     item.classification = ItemClassification.useful
                 else:
-                    # The lists should be moved out of the loop
-                    item = self.create_item(self.random.choices(
-                        list(self.mm_collection.filler_item_names.keys()),
-                        list(self.mm_collection.filler_item_weights.values())
-                    )[0])
+                    item = self.create_item(self.random.choices(self.filler_item_names, self.filler_item_weights)[0])
 
                 self.multiworld.itempool.append(item)
 

--- a/__init__.py
+++ b/__init__.py
@@ -160,6 +160,9 @@ class MegaMixWorld(World):
         if name == self.mm_collection.LEEK_NAME:
             return MegaMixFixedItem(name, ItemClassification.progression_skip_balancing, self.mm_collection.LEEK_CODE, self.player)
 
+        if name in self.mm_collection.filler_item_names:
+            return MegaMixFixedItem(name, ItemClassification.filler, self.mm_collection.filler_item_names.get(name), self.player)
+
         song = self.mm_collection.song_items.get(name)
         return MegaMixSongItem(name, self.player, song)
 
@@ -189,8 +192,16 @@ class MegaMixWorld(World):
         # This is for the extraordinary case of needing to fill a lot of items.
         while items_left > len(song_keys_in_pool):
             for key in song_keys_in_pool:
-                item = self.create_item(key)
-                item.classification = ItemClassification.useful
+                if self.options.duplicate_songs:
+                    item = self.create_item(key)
+                    item.classification = ItemClassification.useful
+                else:
+                    # The lists should be moved out of the loop
+                    item = self.create_item(self.random.choices(
+                        list(self.mm_collection.filler_item_names.keys()),
+                        list(self.mm_collection.filler_item_weights.values())
+                    )[0])
+
                 self.multiworld.itempool.append(item)
 
             items_left -= len(song_keys_in_pool)


### PR DESCRIPTION
`SAFE` rationale: a player's worst nightmare and will appear in the web tracker as:
| Item | Amount |
|------|--------|
| SAFE | 39     |

As mentioned in the Client.py comment it may be worth proactively pulling out static item names (i.e. future traps) to reduce some hard coding. The option is currently a toggle but maybe making it a percentage would satisfy all players.