### PR TITLE
Duplicate Song Percentage

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -199,6 +199,9 @@ class MegaMixContext(CommonContext):
                     if network_item.item == 1:
                         self.leeks_obtained += 1
                         self.check_goal()
+                    elif item_name == "SAFE":
+                        # Maybe move static items out of MegaMixCollection instead of hard coding?
+                        pass
                     else:
                         if self.modded:
                             found, song_pack = self.is_item_in_modded_data(network_item.item)

--- a/Client.py
+++ b/Client.py
@@ -199,7 +199,7 @@ class MegaMixContext(CommonContext):
                     if network_item.item == 1:
                         self.leeks_obtained += 1
                         self.check_goal()
-                    elif item_name == "SAFE":
+                    elif network_item.item == 2:
                         # Maybe move static items out of MegaMixCollection instead of hard coding?
                         pass
                     else:

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -24,7 +24,7 @@ class MegaMixCollections:
     song_locations: Dict[str, int] = {}
     
     filler_item_names: Dict[str, int] = {
-        "SAFE": STARTING_CODE + 1,
+        "SAFE": STARTING_CODE - 1,
     }
     filler_item_weights: Dict[str, int] = {
         "SAFE": 1,

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -22,9 +22,16 @@ class MegaMixCollections:
 
     song_items: Dict[str, SongData] = {}
     song_locations: Dict[str, int] = {}
+    
+    filler_item_names: Dict[str, int] = {
+        "SAFE": STARTING_CODE + 1,
+    }
+    filler_item_weights: Dict[str, int] = {
+        "SAFE": 1,
+    }
 
     def __init__(self) -> None:
-        self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.song_items)
+        self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.filler_item_names, self.song_items)
         self.location_names_to_id = ChainMap(self.song_locations)
 
         difficulty_mapping = {

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -24,7 +24,7 @@ class MegaMixCollections:
     song_locations: Dict[str, int] = {}
     
     filler_item_names: Dict[str, int] = {
-        "SAFE": STARTING_CODE - 1,
+        "SAFE": 2,
     }
     filler_item_weights: Dict[str, int] = {
         "SAFE": 1,

--- a/Options.py
+++ b/Options.py
@@ -32,6 +32,17 @@ class AdditionalSongs(Range):
     display_name = "Additional Song Count"
 
 
+class DuplicateSongPercentage(Range):
+    """
+    Percentage of duplicate songs to place in remaining filler slots.
+    Duplicate songs are considered Useful and thus out of logic.
+    """
+    range_start = 0
+    range_end = 100
+    default = 100
+    display_name = "Duplicate Song Percentage"
+
+
 class DifficultyMode(Choice):
     """Difficulty Select, All songs will be of the selected difficulty (Manual allows a range, Any gives a random difficulty for each song)
     - Any: Each song will be of a randomly chosen difficulty
@@ -212,6 +223,7 @@ class ExcludeSinger(OptionSet):
 class MegaMixOptions(PerGameCommonOptions):
     allow_megamix_dlc_songs: AllowMegaMixDLCSongs
     auto_remove_songs: AutoRemoveCleared
+    duplicate_song_percentage: DuplicateSongPercentage
     starting_song_count: StartingSongs
     additional_song_count: AdditionalSongs
     song_difficulty_mode: DifficultyMode


### PR DESCRIPTION
`SAFE` rationale: a player's worst nightmare and will appear in the web tracker as:
| Item | Amount |
|------|--------|
| SAFE | 39     |

There may be an ID overlap with the filler and `location_id_index`.
As mentioned in the Client.py comment it may be worth proactively pulling out static item names (i.e. future traps) to reduce some hard coding.
Redone for hopefully cleaner review.