### PR TITLE
DataHandler - Acknowledge player_files_path

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -3,6 +3,8 @@ import pkgutil
 import re
 import os
 import shutil
+import sys
+import Utils
 from .SymbolFixer import fix_song_name
 from collections import defaultdict
 import ast
@@ -361,10 +363,14 @@ def find_linked_numbers(number_list):
     return list(lower_numbers)
 
 
-def extract_mod_data_to_json(folder_path: str) -> list[Any]:
+def extract_mod_data_to_json() -> list[Any]:
     """
     Extracts mod data from YAML files and converts it to a list of dictionaries.
     """
+
+    folder_path = sys.argv(sys.argv.index("--player_files_path")+1) if "--player_files_path" in sys.argv else Utils.user_path(Utils.get_settings()["generator"]["player_files_path"])
+
+    print(f"Checking YAMLs for megamix_mod_data at {folder_path}")
     if not os.path.isdir(folder_path):
         raise ValueError(f"The path {folder_path} is not a valid directory.")
 

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -368,7 +368,8 @@ def extract_mod_data_to_json() -> list[Any]:
     Extracts mod data from YAML files and converts it to a list of dictionaries.
     """
 
-    folder_path = sys.argv(sys.argv.index("--player_files_path")+1) if "--player_files_path" in sys.argv else Utils.user_path(Utils.get_settings()["generator"]["player_files_path"])
+    user_path = Utils.user_path(Utils.get_settings()["generator"]["player_files_path"])
+    folder_path = sys.argv(sys.argv.index("--player_files_path")+1) if "--player_files_path" in sys.argv else user_path
 
     print(f"Checking YAMLs for megamix_mod_data at {folder_path}")
     if not os.path.isdir(folder_path):

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -369,7 +369,7 @@ def extract_mod_data_to_json() -> list[Any]:
     """
 
     user_path = Utils.user_path(Utils.get_settings()["generator"]["player_files_path"])
-    folder_path = sys.argv(sys.argv.index("--player_files_path")+1) if "--player_files_path" in sys.argv else user_path
+    folder_path = sys.argv[sys.argv.index("--player_files_path")+1] if "--player_files_path" in sys.argv else user_path
 
     print(f"Checking YAMLs for megamix_mod_data at {folder_path}")
     if not os.path.isdir(folder_path):

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -4,7 +4,6 @@ from .SymbolFixer import fix_song_name
 
 # Python
 import random
-import Utils
 from typing import Dict, List, Tuple
 from collections import ChainMap
 
@@ -52,7 +51,7 @@ class MegaMixCollections:
         difficulty_order = ['E', 'N', 'H', 'EX', 'EXEX']
 
         json_data = load_zipped_json_file("songData.json")
-        mod_data = extract_mod_data_to_json(Utils.user_path(Utils.get_settings()["generator"]["player_files_path"]))
+        mod_data = extract_mod_data_to_json()
         base_game_ids = set()
 
         for song in json_data:


### PR DESCRIPTION
Not ready to be merged without addressing the long elephant in the room.

How PyCharm handles it:
```Py
folder_path = sys.argv(
        sys.argv.index("--player_files_path") + 1) if "--player_files_path" in sys.argv else Utils.user_path(
        Utils.get_settings()["generator"]["player_files_path"])
```

Semi-related, but now that the YAMLs can be more reliably honed in on I don't believe it's worth raising a generation error if the path is not a directory, even if it would be caught early. Log it, then return empty?