### PR TITLE
Client: Restore on autorelease

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -279,7 +279,7 @@ class MegaMixContext(CommonContext):
     async def end_goal(self):
         message = [{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}]
 
-        if Permission.from_text(self.permissions.get("release")) is Permission.auto:
+        if Permission.auto & Permission.from_text(self.permissions.get("release")) == Permission.auto:
             await self.restore_songs()
         elif self.autoRemove:
             await self.remove_songs()

--- a/Client.py
+++ b/Client.py
@@ -27,7 +27,7 @@ from CommonClient import (
     server_loop,
     gui_enabled,
 )
-from NetUtils import NetworkItem, ClientStatus
+from NetUtils import NetworkItem, ClientStatus, Permission
 
 
 class DivaClientCommandProcessor(ClientCommandProcessor):
@@ -245,7 +245,6 @@ class MegaMixContext(CommonContext):
             print(f"Watch task for {file_name} was canceled.")
 
     def receive_location_check(self, song_data):
-
         # If song is not dummy song
         if song_data.get('pvId') != 144:
             # Check if player got a good enough grade on the song
@@ -278,8 +277,12 @@ class MegaMixContext(CommonContext):
 
     async def end_goal(self):
         message = [{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}]
-        if self.autoRemove:
+
+        if Permission.from_text(self.permissions.get("release")) is Permission.auto:
+            await self.restore_songs()
+        elif self.autoRemove:
             await self.remove_songs()
+
         await self.send_msgs(message)
 
     async def send_checks(self):

--- a/Client.py
+++ b/Client.py
@@ -245,6 +245,7 @@ class MegaMixContext(CommonContext):
             print(f"Watch task for {file_name} was canceled.")
 
     def receive_location_check(self, song_data):
+
         # If song is not dummy song
         if song_data.get('pvId') != 144:
             # Check if player got a good enough grade on the song


### PR DESCRIPTION
On goal, if the room is autorelease automatically autorestore. Auto. With the autorestore the pv_dbs can return to an initially playable state without user intervention or having to disable the mod (for base songs).

There is one caveat that should be improved: if `restore_songs()` fails, such as a missing *mod_pv_dbCOPY.txt*. Since this sends before the CLIENT_GOAL message if that call fails the goal is never sent. This happened to me in testing since I might have deleted the mod's copy at some point. In the absence of a copy, at best the mod could manually calculate the lengths to restore to. Or just try block it.

This should also be made to not `send_checks()` [on goal song](https://github.com/Cynichill/DivaAPworld/blob/testing/Client.py#L262-L272) (based on indentation) to avoid a pointless run through the pv_dbs only to copy over them after, or worse a race condition.