### PR TITLE
init: modpath docstring

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,7 +35,7 @@ components.append(Component(
 class MegaMixSettings(settings.Group):
     class ModPath(settings.LocalFolderPath):
         """
-        "Mods" folder location for Hatsune Miku Project DIVA Mega Mix+. Usually ends with "/mods".
+        Mod folder location for Hatsune Miku Project DIVA Mega Mix+. Usually ends with "/mods".
         Players (Mega Mix Clients) must have this set correctly in THEIR host.yaml.
         Generating and hosting do not rely on this.
         """

--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,11 @@ components.append(Component(
 
 class MegaMixSettings(settings.Group):
     class ModPath(settings.LocalFolderPath):
-        """Path to diva mods folder"""
+        """
+        "Mods" folder location for Hatsune Miku Project DIVA Mega Mix+. Usually ends with "/mods".
+        Players (Mega Mix Clients) must have this set correctly in THEIR host.yaml.
+        Generating and hosting do not rely on this.
+        """
 
     mod_path: ModPath = ModPath(
         "C:/Program Files (x86)/Steam/steamapps/common/Hatsune Miku Project DIVA Mega Mix Plus/mods")

--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,7 @@ class MegaMixSettings(settings.Group):
         Players (Mega Mix Clients) must have this set correctly in THEIR host.yaml.
         Generating and hosting do not rely on this.
         """
+        description = "Hatsune Miku Project DIVA Mega Mix+ mods folder"
 
     mod_path: ModPath = ModPath(
         "C:/Program Files (x86)/Steam/steamapps/common/Hatsune Miku Project DIVA Mega Mix Plus/mods")


### PR DESCRIPTION
To cut down on some support requests.

The folder select window title also changed from `Select ModPath` to `Select Hatsune Miku Project DIVA Mega Mix+ mods folder`.