### PR TITLE
Freeplay improvements

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -176,10 +176,11 @@ class MegaMixContext(CommonContext):
     def is_item_in_modded_data(self, item_id):
         target_song_id = int(item_id) // 10
 
-        for pack, songs in self.modData.items():  # Iterate through each pack
-            for song in songs:  # Iterate through each song in the pack
-                if song[1] == target_song_id:
-                    return pack
+        if self.modded:
+            for pack, songs in self.modData.items():
+                for song in songs:
+                    if song[1] == target_song_id:
+                        return pack
         return "ArchipelagoMod"
 
     async def receive_item(self):
@@ -196,7 +197,7 @@ class MegaMixContext(CommonContext):
                         # Maybe move static items out of MegaMixCollection instead of hard coding?
                         pass
                     else:
-                        song_pack = self.is_item_in_modded_data(network_item.item) if self.modded else "ArchipelagoMod"
+                        song_pack = self.is_item_in_modded_data(network_item.item)
 
                         if song_pack not in ids_to_packs:
                             ids_to_packs[song_pack] = []
@@ -210,7 +211,7 @@ class MegaMixContext(CommonContext):
         if not self.sent_unlock_message and self.leeks_obtained >= self.leeks_needed:
             self.sent_unlock_message = True
             logger.info(f"Got enough leeks! Unlocking goal song: {self.goal_song}")
-            song_pack = self.is_item_in_modded_data(self.goal_id) if self.modded else "ArchipelagoMod"
+            song_pack = self.is_item_in_modded_data(self.goal_id)
             song_unlock(self.path, [self.goal_id], False, song_pack)
 
 
@@ -332,7 +333,7 @@ class MegaMixContext(CommonContext):
 
         # Check for matches where all suffixes have been found
         for item in finished_songs:
-            song_pack = self.is_item_in_modded_data(item) if self.modded else "ArchipelagoMod"
+            song_pack = self.is_item_in_modded_data(item)
 
             if song_pack not in ids_to_packs:
                 ids_to_packs[song_pack] = []

--- a/Client.py
+++ b/Client.py
@@ -257,7 +257,7 @@ class MegaMixContext(CommonContext):
 
         if Permission.auto & Permission.from_text(self.permissions.get("release")) == Permission.auto:
             await self.restore_songs()
-        elif self.autoRemove:
+        elif self.autoRemove and not self.freeplay:
             await self.remove_songs()
 
         await self.send_msgs(message)
@@ -267,7 +267,7 @@ class MegaMixContext(CommonContext):
         await self.send_msgs(message)
         self.remove_found_checks()
         self.found_checks.clear()
-        if self.autoRemove:
+        if self.autoRemove and not self.freeplay:
             await self.remove_songs()
 
     def remove_found_checks(self):
@@ -334,8 +334,13 @@ class MegaMixContext(CommonContext):
     async def freeplay_toggle(self):
         self.freeplay = not self.freeplay
 
-        song_ids = list(set(int(location) // 10 for location in self.location_ids))
-        song_ids.append(self.goal_id)
+        song_ids = [missing for missing in self.missing_checks[::self.checks_per_song]]
+        if not self.freeplay:
+            song_ids = [received.item for received in self.previous_received if received.item in song_ids]
+            if self.leeks_obtained >= self.leeks_needed:
+                song_ids.append(self.goal_id)
+
+        print(song_ids)
 
         freeplay_song_list(self.mod_pv_list, song_ids, self.freeplay)
 

--- a/Client.py
+++ b/Client.py
@@ -208,7 +208,7 @@ class MegaMixContext(CommonContext):
                 self.sent_unlock_message = True
                 logger.info(f"Got enough leeks! Unlocking goal song: {self.goal_song}")
 
-            song_pack = self.is_item_in_modded_data(self.goal_id) if self.modded else "ArchipelagoMod"
+            song_pack = self.song_id_to_pack(self.goal_id) if self.modded else "ArchipelagoMod"
             song_unlock(self.path, [self.goal_id], False, song_pack)
 
 

--- a/Client.py
+++ b/Client.py
@@ -203,7 +203,7 @@ class MegaMixContext(CommonContext):
 
 
     def check_goal(self):
-        if  self.leeks_obtained >= self.leeks_needed:
+        if self.leeks_obtained >= self.leeks_needed:
             if not self.sent_unlock_message:
                 self.sent_unlock_message = True
                 logger.info(f"Got enough leeks! Unlocking goal song: {self.goal_song}")

--- a/Client.py
+++ b/Client.py
@@ -208,7 +208,7 @@ class MegaMixContext(CommonContext):
                 self.sent_unlock_message = True
                 logger.info(f"Got enough leeks! Unlocking goal song: {self.goal_song}")
 
-            song_pack = self.song_id_to_pack(self.goal_id) if self.modded else "ArchipelagoMod"
+            song_pack = self.song_id_to_pack(self.goal_id)
             song_unlock(self.path, [self.goal_id], False, song_pack)
 
 

--- a/Client.py
+++ b/Client.py
@@ -14,7 +14,7 @@ from .DataHandler import (
     generate_modded_paths,
     create_copies,
     restore_originals,
-    restore_song_list,
+    freeplay_song_list,
 )
 from CommonClient import (
     CommonContext,
@@ -341,11 +341,11 @@ class MegaMixContext(CommonContext):
         song_ids = list(set(int(location) // 10 for location in self.location_ids))
         song_ids.append(self.goal_id)
 
+        freeplay_song_list(self.mod_pv_list, song_ids, self.freeplay)
+
         if self.freeplay:
-            restore_song_list(self.mod_pv_list, song_ids, True)
             logger.info("Restored non-AP songs!")
         else:
-            restore_song_list(self.mod_pv_list, song_ids, False)
             logger.info("Removed non-AP songs!")
 
     async def restore_songs(self):

--- a/Client.py
+++ b/Client.py
@@ -320,13 +320,9 @@ class MegaMixContext(CommonContext):
             logger.info("Auto Remove Set to Off")
 
     async def remove_songs(self):
-        group_songs = {}
-        for loc in self.prev_found:
-            prefix, last = divmod(loc, 10)
-            group_songs.setdefault(prefix, set()).add(last)
-        finished_songs = [prefix * 10 for prefix, digits in group_songs.items() if {0, 1} <= digits]
-        ids_to_packs = {}
+        finished_songs = self.prev_found[::self.checks_per_song]
 
+        ids_to_packs = {}
         for item in finished_songs:
             ids_to_packs.setdefault(self.song_id_to_pack(item), []).append(item)
 

--- a/Client.py
+++ b/Client.py
@@ -334,13 +334,16 @@ class MegaMixContext(CommonContext):
     async def freeplay_toggle(self):
         self.freeplay = not self.freeplay
 
-        song_ids = [missing for missing in self.missing_checks[::self.checks_per_song]]
+        song_ids = [location_id for location_id in list(self.location_ids)[::self.checks_per_song]
+                    if location_id not in [i.item for i in self.previous_received]]
+
         if not self.freeplay:
-            song_ids = [received.item for received in self.previous_received if received.item in song_ids]
+            song_ids = [received.item for received in self.previous_received if received.item in self.missing_checks]
+
             if self.leeks_obtained >= self.leeks_needed:
                 song_ids.append(self.goal_id)
-
-        print(song_ids)
+        elif self.leeks_obtained < self.leeks_needed:
+            song_ids.append(self.goal_id)
 
         freeplay_song_list(self.mod_pv_list, song_ids, self.freeplay)
 

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -125,12 +125,18 @@ def generate_modded_paths(processed_data, base_path):
     return list(modded_paths)
 
 
-def restore_song_list(file_paths):
-    search = re.compile(r"^#ARCH#(.*)", re.MULTILINE)
+def freeplay_song_list(file_paths, skip_ids, freeplay: bool):
+    processed_ids = "|".join([str(x).zfill(3) for x in skip_ids])
 
     for file_path in file_paths:
         with open(file_path, 'r+', encoding='utf-8') as file:
-            file_data = re.sub(search, r"\g<1>", file.read())
+            file_data = file.read()
+            if freeplay:
+                file_data = re.sub(r"^#ARCH#(.*)", r"\g<1>", file_data, flags=re.MULTILINE)
+                file_data = remove_song(file_data, processed_ids)
+            else:
+                file_data = re.sub("PLACEHOLDER", r"#ARCH#\g<1>", file_data)
+                file_data = modify_mod_pv(file_data, processed_ids)
             file.seek(0)
             file.write(file_data)
             file.truncate()

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -132,11 +132,11 @@ def freeplay_song_list(file_paths, skip_ids: list[int], freeplay: bool):
         with open(file_path, 'r+', encoding='utf-8') as file:
             file_data = file.read()
             if freeplay:
-                file_data = modify_mod_pv(file_data, f"(?!({processed_ids})\.)\d+")
+                file_data = modify_mod_pv(file_data, rf"(?!({processed_ids})\.)\d+")
                 file_data = remove_song(file_data, processed_ids)
             else:
                 file_data = modify_mod_pv(file_data, processed_ids)
-                file_data = remove_song(file_data, f"(?!({processed_ids})\.)\d+")
+                file_data = remove_song(file_data, rf"(?!({processed_ids})\.)\d+")
             file.seek(0)
             file.write(file_data)
             file.truncate()

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -125,18 +125,18 @@ def generate_modded_paths(processed_data, base_path):
     return list(modded_paths)
 
 
-def freeplay_song_list(file_paths, skip_ids, freeplay: bool):
-    processed_ids = "|".join([str(x).zfill(3) for x in skip_ids])
+def freeplay_song_list(file_paths, skip_ids: list[int], freeplay: bool):
+    processed_ids = "|".join([str(x // 10).zfill(3) for x in skip_ids])
 
     for file_path in file_paths:
         with open(file_path, 'r+', encoding='utf-8') as file:
             file_data = file.read()
             if freeplay:
-                file_data = re.sub(r"^#ARCH#(.*)", r"\g<1>", file_data, flags=re.MULTILINE)
+                file_data = modify_mod_pv(file_data, f"(?!({processed_ids})\.)\d+")
                 file_data = remove_song(file_data, processed_ids)
             else:
-                file_data = re.sub("PLACEHOLDER", r"#ARCH#\g<1>", file_data)
                 file_data = modify_mod_pv(file_data, processed_ids)
+                file_data = remove_song(file_data, f"(?!({processed_ids})\.)\d+")
             file.seek(0)
             file.write(file_data)
             file.truncate()
@@ -174,7 +174,7 @@ def modify_mod_pv(pv_db: str, songs: str) -> str:
 
 
 def remove_song(pv_db: str, songs: str) -> str:
-    return re.sub(rf"^(pv_({songs})\.difficulty\.(?:easy|normal|hard|extreme).length=\d)$", r"#ARCH#\g<1>", pv_db, flags=re.MULTILINE)
+    return re.sub(rf"^(pv_(?!(144|700)\.)({songs})\.difficulty\.(?:easy|normal|hard|extreme).length=\d)$", r"#ARCH#\g<1>", pv_db, flags=re.MULTILINE)
 
 
 def extract_mod_data_to_json() -> list[Any]:


### PR DESCRIPTION
- Fixes freeplay toggle regression I caused in 9f229ff2bcc57472c1d05bb1ea7dce101e9df7d3
- Auto remove songs is no longer called while in freeplay
  - Obtaining songs *in freeplay* worked before and still does
- Cleared songs are now available in freeplay
- Available songs (and goal if McGuffins are met) are now available in freeplay
  - As of opening this PR, I'm not a fan of how verbose the function became to handle the goal song.
     - The one and only previous check originated from `check_goal`
  - Side effect: it should now be possible to play start to finish in freeplay
    - An eventual auto-freeplay should be really easy, just provide `freeplay_toggle` a `force` argument.
    
[A small, out of scope optimization](https://github.com/Cynichill/DivaAPworld/pull/35/files#diff-00faf9ddca954cb25c8ad342486928312007c387eecaa4c70bcd16cbaaa8cdf8L326-R323) was done to `remove_songs` but should be functionally identical. I had no issues with auto/song removal when testing *not in freeplay*.