### PR TITLE
Client: Fix goal unlock on datapackage received

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -149,6 +149,7 @@ class MegaMixContext(CommonContext):
                 # Connected package not recieved yet, wait for datapackage request after connected package
                 return
             self.leeks_obtained = 0
+            self.sent_unlock_message = False
             self.previous_received = []
 
             self.location_name_to_ap_id = args["data"]["games"]["Hatsune Miku Project Diva Mega Mix+"][
@@ -207,9 +208,11 @@ class MegaMixContext(CommonContext):
 
 
     def check_goal(self):
-        if not self.sent_unlock_message and self.leeks_obtained >= self.leeks_needed:
-            self.sent_unlock_message = True
-            logger.info(f"Got enough leeks! Unlocking goal song: {self.goal_song}")
+        if  self.leeks_obtained >= self.leeks_needed:
+            if not self.sent_unlock_message:
+                self.sent_unlock_message = True
+                logger.info(f"Got enough leeks! Unlocking goal song: {self.goal_song}")
+
             song_pack = self.is_item_in_modded_data(self.goal_id) if self.modded else "ArchipelagoMod"
             song_unlock(self.path, [self.goal_id], False, song_pack)
 

--- a/Client.py
+++ b/Client.py
@@ -149,7 +149,6 @@ class MegaMixContext(CommonContext):
                 # Connected package not recieved yet, wait for datapackage request after connected package
                 return
             self.leeks_obtained = 0
-            self.sent_unlock_message = False
             self.previous_received = []
 
             self.location_name_to_ap_id = args["data"]["games"]["Hatsune Miku Project Diva Mega Mix+"][


### PR DESCRIPTION
A problem I introduced in 79c3e7ac0be21b3293f0eb24e951eb2748107c23.
The combined if statement would prevent the goal from unlocking when the datapackage is received. 
Very common in asyncs. In syncs it's more likely the McGuffin count will be reached *after* the datapackage.