### PR TITLE
Improve test run time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Archipelago | Setup
         run: |
+          find ./worlds -mindepth 1 -maxdepth 1 -type d -regextype posix-extended ! -regex '.*/(megamix|generic|alttp)' -exec rm -rf {} \;
           python -m pip install --upgrade pip
           pip install pytest pytest-subtests pytest-xdist
           python ModuleUpdate.py --yes --force --append "WebHostLib/requirements.txt"


### PR DESCRIPTION
3-4 minutes per run down to 1-1.5 by deleting other official worlds which we really do not care about. (see Action history)
Bonus: Won't get random alerts of other worlds failing tests.