### PR TITLE
DH: safe_load_all

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -207,13 +207,13 @@ def extract_mod_data_to_json() -> list[Any]:
 
                         # Process each mod_data block
                         for _ in matches:
-                            mod_data_match = yaml.safe_load(file_content)
-                            mod_data_content = mod_data_match.get("Hatsune Miku Project Diva Mega Mix+", {}).get("megamix_mod_data", '""')
+                            for single_yaml in yaml.safe_load_all(file_content):
+                                mod_data_content = single_yaml.get("Hatsune Miku Project Diva Mega Mix+", {}).get("megamix_mod_data", None)
 
-                            if isinstance(mod_data_content, dict) or not mod_data_content:
-                                continue
+                                if isinstance(mod_data_content, dict) or not mod_data_content:
+                                    continue
 
-                            all_mod_data.append(json.loads(mod_data_content))
+                                all_mod_data.append(json.loads(mod_data_content))
 
     total = sum(len(pack) for packList in all_mod_data for pack in packList.values())
     logger.debug(f"Found {total} songs")


### PR DESCRIPTION
Not to be confused with a single player YAML combining multiple `game`s, but when a single YAML combines multiple single players sectioned off with `---`.

Tested with 1Y1P gens and 1YnP gens.

![Untitled](https://github.com/user-attachments/assets/ed469f2a-759e-4cc1-9fa6-79e0644fdb20)
