### PR TITLE
init: Simplify slim modData

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -232,7 +232,7 @@ def get_player_specific_ids(mod_data):
     song_ids = []  # Initialize an empty list to store song IDs
 
     if mod_data == "":
-        return song_ids
+        return {}, song_ids
 
     data_dict = json.loads(mod_data)
 
@@ -241,4 +241,4 @@ def get_player_specific_ids(mod_data):
             song_id = song[1]
             song_ids.append(song_id)
 
-    return song_ids  # Return the list of song IDs
+    return data_dict, song_ids  # Return the list of song IDs


### PR DESCRIPTION
Specifically to avoid extra `json.loads()`.
Verified `self.player_specific_mod_data` using two YAMLs with different modstrings. Connected one slot, modified its related mod_pv_db, left the other slot's mod_pv_db alone.

This was easier than expected due to being in `generate_early()`. The extreme route would be splitting them out on class init, but that's way too much effort and wasteful such as when the game ends up not being rolled.