### PR TITLE
Client: better prev_found check

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -227,14 +227,15 @@ class MegaMixContext(CommonContext):
             print(f"Watch task for {file_name} was canceled.")
 
     def receive_location_check(self, song_data):
-
         logger.debug(song_data)
+
         # If song is not dummy song
         if song_data.get('pvId') != 144:
             location_id = int(song_data.get('pvId') * 10)
+            location_checks = list(range(location_id, location_id + self.checks_per_song))
 
             if not location_id == self.goal_id:
-                if location_id in self.prev_found:
+                if set(location_checks).issubset(set(self.prev_found)):
                     logger.info("No checks to send: Song checks previously sent or collected")
                     return
 

--- a/Client.py
+++ b/Client.py
@@ -232,10 +232,10 @@ class MegaMixContext(CommonContext):
         # If song is not dummy song
         if song_data.get('pvId') != 144:
             location_id = int(song_data.get('pvId') * 10)
-            location_checks = list(range(location_id, location_id + self.checks_per_song))
+            location_checks = set(range(location_id, location_id + self.checks_per_song))
 
             if not location_id == self.goal_id:
-                if set(location_checks).issubset(set(self.prev_found)):
+                if location_checks.issubset(set(self.prev_found)):
                     logger.info("No checks to send: Song checks previously sent or collected")
                     return
 


### PR DESCRIPTION
Before: Another game collected `Song-0` but not `Song-1`. The check only considered `-0` in `prev_found` for both.
After: Check the entire list of possible locations against what is in `prev_found`.

The other uses of `[::self.checks_per_song]` were `freeplay` and `remove_songs`, so no issue there.

Tested:
 - Admin console: `/send_location MikuPlayer Song [ID]-0`
 - `MikuPlayer sent Item to OtherPlayer (Song [ID]-0)`
 - Send a clear of `ID` through `results.json`
 - `MikuPlayer sent OtherItem to OtherOtherPlayer (Song [ID]-1)`