### PR TITLE
JSONMM: Extra edge case

### DIFF
--- a/generator_megamix/json_megamix.py
+++ b/generator_megamix/json_megamix.py
@@ -56,7 +56,7 @@ def process_single_mod(mod_pv_db_path: str, mod_dir: str) -> tuple[set[int], lis
 
     with open(mod_pv_db_path, "r", encoding='utf-8') as input_file:
         mod_pv_db = input_file.read()
-    mod_pv_db = re.findall(rf'^pv_(\d+)\.(song_name_en|difficulty)(?:\.([^.]+)\.(\d|length)\.?(level|script_file_name)?)?=(.*)$', mod_pv_db, re.MULTILINE)
+    mod_pv_db = set(re.findall(rf'^pv_(\d+)\.(song_name_en|difficulty)(?:\.([^.]+)\.(\d|length)\.?(level|script_file_name|attribute\.extra)?)?=(.*)$', mod_pv_db, re.MULTILINE))
 
     for line in mod_pv_db:
         song_id, song_prop, diff_rating, diff_index_length, diff_prop, value = line
@@ -68,7 +68,14 @@ def process_single_mod(mod_pv_db_path: str, mod_dir: str) -> tuple[set[int], lis
             case "song_name_en":
                 songs[song_id][0] = fix_song_name(value).replace("'", "''")
             case "difficulty" if not diff_rating == "encore":
+                extra_check = song_id, song_prop, diff_rating, '1', 'attribute.extra', '1'
                 diff_rating = "exextreme" if diff_index_length == "1" and diff_rating == "extreme" else diff_rating
+
+                # Sanity check for invalid extreme data (starts at 1 index/out of 0-2 range of length prop): check the extra attribute.
+                if diff_rating is "exextreme" and extra_check not in mod_pv_db:
+                    print(f"{song_id} appears ExEx but lacks attribute, downgrade to Ex")
+                    diff_rating = "extreme"
+
                 diff_index = difficulties.index(diff_rating)
 
                 if diff_index_length == "length" and value == "0":

--- a/generator_megamix/json_megamix.py
+++ b/generator_megamix/json_megamix.py
@@ -56,7 +56,7 @@ def process_single_mod(mod_pv_db_path: str, mod_dir: str) -> tuple[set[int], lis
 
     with open(mod_pv_db_path, "r", encoding='utf-8') as input_file:
         mod_pv_db = input_file.read()
-    mod_pv_db = set(re.findall(rf'^pv_(\d+)\.(song_name_en|difficulty)(?:\.([^.]+)\.(\d|length)\.?(level|script_file_name|attribute\.extra)?)?=(.*)$', mod_pv_db, re.MULTILINE))
+    mod_pv_db = set(re.findall(rf'^(?:#ARCH#)?pv_(\d+)\.(song_name_en|difficulty)(?:\.([^.]+)\.(\d|length)\.?(level|script_file_name|attribute\.extra)?)?=(.*)$', mod_pv_db, re.MULTILINE))
 
     for line in mod_pv_db:
         song_id, song_prop, diff_rating, diff_index_length, diff_prop, value = line


### PR DESCRIPTION
Cover a specific edge case found in `Valentine's Day Collaboration Song Pack 2025`.

The original Generator did not stand a chance and the songs were not picked up. Prior to this fix the new Generator got all but the difficulty right.

5828 and 5829 both have the following:
```
pv_582#.difficulty.extreme.1.(...)    # 1-index instead of 0-index
pv_582#.difficulty.extreme.length=8.0 # Not 0-2, not an integer
```
One assumption would be these appear in-game as ExEx, but they appear as Ex without the attribute.
There is now a specific exception made for *all* ExEx to check they have `attribute.extra=1`. Hopefully in the least impactful way without another rewrite.

`["Heart Forecast",5828,9]` is now `["Heart Forecast",5828,288]`.

Very light testing. Across a lot of sample mod_pv_dbs the exception was only made for 5828 and 5829.