### PR TITLE
MMC: Item Groups

### DIFF
--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -87,10 +87,6 @@ class MegaMixCollections:
             if not songData.modded and song_id in mod_ids:
                 continue
 
-            # Skip song if disallowed singer is found
-            if not songData.modded and disallowed_singer.intersection(songData.singers):
-                continue
-
             for diff in allowed_diff:
                 if songData.difficulties[diff] > 0.0: # Has that difficulty
                     if diff_lower <= songData.difficulties[diff] <= diff_higher:

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -105,12 +105,12 @@ class MegaMixCollections:
             "BaseSongs": {name for name, data in base_songs.items() if not data.DLC},
             "DLCSongs": {name for name, data in base_songs.items() if data.DLC},
 
-            "SingerMiku": {name for name, data in base_songs.items() if "Hatsune Miku" in data.singers},
-            "SingerRin": {name for name, data in base_songs.items() if "Kagamine Rin" in data.singers},
-            "SingerLen": {name for name, data in base_songs.items() if "Kagamine Len" in data.singers},
-            "SingerLuka": {name for name, data in base_songs.items() if "Megurine Luka" in data.singers},
-            "SingerKAITO": {name for name, data in base_songs.items() if "KAITO" in data.singers},
-            "SingerMEIKO": {name for name, data in base_songs.items() if "MEIKO" in data.singers},
+            "MikuSongs": {name for name, data in base_songs.items() if "Hatsune Miku" in data.singers},
+            "RinSongs": {name for name, data in base_songs.items() if "Kagamine Rin" in data.singers},
+            "LenSongs": {name for name, data in base_songs.items() if "Kagamine Len" in data.singers},
+            "LukaSongs": {name for name, data in base_songs.items() if "Megurine Luka" in data.singers},
+            "KAITOSongs": {name for name, data in base_songs.items() if "KAITO" in data.singers},
+            "MEIKOSongs": {name for name, data in base_songs.items() if "MEIKO" in data.singers},
         }
 
         # Disabled since song_items is shared across all players. Need to filter to player_specific_ids.

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -67,7 +67,8 @@ class MegaMixCollections:
             for i in range(2):
                 self.song_locations[f"{song_name}-{i}"] = (song_data.code + i)
 
-    def get_songs_with_settings(self, dlc: bool, mod_ids: List[int], allowed_diff: List[int], disallowed_singer: set[str], diff_lower: float, diff_higher: float) -> List[str]:
+
+    def get_songs_with_settings(self, dlc: bool, mod_ids: List[int], allowed_diff: List[int], diff_lower: float, diff_higher: float) -> List[str]:
         """Gets a list of all songs that match the filter settings. Difficulty thresholds are inclusive."""
         filtered_list = []
 

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -100,23 +100,22 @@ class MegaMixCollections:
         return filtered_list
 
     def get_item_name_groups(self) -> dict[str, set]:
+        base_songs = {name: data for name, data in self.song_items.items() if not data.modded}
         groups = {
-            "BaseSongs": {name for name, data in self.song_items.items() if not data.modded and not data.DLC},
-            "DLCSongs": {name for name, data in self.song_items.items() if not data.modded and data.DLC},
+            "BaseSongs": {name for name, data in base_songs.items() if not data.DLC},
+            "DLCSongs": {name for name, data in base_songs.items() if data.DLC},
+
+            "SingerMiku": {name for name, data in base_songs.items() if "Hatsune Miku" in data.singers},
+            "SingerRin": {name for name, data in base_songs.items() if "Kagamine Rin" in data.singers},
+            "SingerLen": {name for name, data in base_songs.items() if "Kagamine Len" in data.singers},
+            "SingerLuka": {name for name, data in base_songs.items() if "Megurine Luka" in data.singers},
+            "SingerKAITO": {name for name, data in base_songs.items() if "KAITO" in data.singers},
+            "SingerMEIKO": {name for name, data in base_songs.items() if "MEIKO" in data.singers},
         }
 
         # Disabled since song_items is shared across all players. Need to filter to player_specific_ids.
         #modded = {name for name, data in self.song_items.items() if data.modded}
         #if modded: # test_groups::TestNameGroups::test_item_name_groups_not_empty
         #    groups.update({"ModdedSongs": modded})
-
-        for name, data in self.song_items.items():
-            if data.modded:
-                continue
-
-            for singer in data.singers:
-                singer = singer.split(" ").pop() # Hatsune Miku -> Miku
-                groups.setdefault(f"Singer{singer}", set())
-                groups[f"Singer{singer}"].add(name)
 
         return groups

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -26,7 +26,6 @@ class MegaMixCollections:
     }
 
     def __init__(self) -> None:
-        self.song_items = SONG_DATA
         self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.filler_item_names, self.song_items)
         self.location_names_to_id = ChainMap(self.song_locations)
 

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -29,10 +29,6 @@ class MegaMixCollections:
         self.song_items = SONG_DATA
         self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.filler_item_names, self.song_items)
         self.location_names_to_id = ChainMap(self.song_locations)
-        self.item_name_groups = {
-            "BaseSongs": {name for name, data in self.song_items.items() if not data.modded and not data.DLC},
-            "DLCSongs": {name for name, data in self.song_items.items() if not data.modded and data.DLC},
-        }
 
         self.song_items = SONG_DATA
         mod_data = extract_mod_data_to_json()
@@ -61,12 +57,6 @@ class MegaMixCollections:
                         self.song_items[song_name] = SongData(item_id, song_id, [], False, True, diff_info)
 
         self.item_names_to_id.update({name: data.code for name, data in self.song_items.items()})
-
-        modded_group = {name for name, data in self.song_items.items() if data.modded}
-        if modded_group: # test_groups::TestNameGroups::test_item_name_groups_not_empty
-            self.item_name_groups.update({
-                "ModdedSongs": modded_group
-            })
 
         for song_name, song_data in self.song_items.items():
             if song_data.code % 2 != 0:  # Fix code for covers
@@ -108,3 +98,25 @@ class MegaMixCollections:
                         break
 
         return filtered_list
+
+    def get_item_name_groups(self) -> dict[str, set]:
+        groups = {
+            "BaseSongs": {name for name, data in self.song_items.items() if not data.modded and not data.DLC},
+            "DLCSongs": {name for name, data in self.song_items.items() if not data.modded and data.DLC},
+        }
+
+        # Disabled since song_items is shared across all players. Need to filter to player_specific_ids.
+        #modded = {name for name, data in self.song_items.items() if data.modded}
+        #if modded: # test_groups::TestNameGroups::test_item_name_groups_not_empty
+        #    groups.update({"ModdedSongs": modded})
+
+        for name, data in self.song_items.items():
+            if data.modded:
+                continue
+
+            for singer in data.singers:
+                singer = singer.split(" ").pop() # Hatsune Miku -> Miku
+                groups.setdefault(f"Singer{singer}", set())
+                groups[f"Singer{singer}"].add(name)
+
+        return groups

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -26,12 +26,18 @@ class MegaMixCollections:
     }
 
     def __init__(self) -> None:
+        self.song_items = SONG_DATA
         self.item_names_to_id = ChainMap({self.LEEK_NAME: self.LEEK_CODE}, self.filler_item_names, self.song_items)
         self.location_names_to_id = ChainMap(self.song_locations)
+        self.item_name_groups = {
+            "BaseSongs": {name for name, data in self.song_items.items() if not data.modded and not data.DLC},
+            "DLCSongs": {name for name, data in self.song_items.items() if not data.modded and data.DLC},
+            "ModdedSongs": {}
+        }
 
         self.song_items = SONG_DATA
         mod_data = extract_mod_data_to_json()
-        base_game_ids = [song_data.songID for song_data in SONG_DATA.values() if song_data.songID is not None]
+        base_game_ids = {song_data.songID for song_data in SONG_DATA.values() if song_data.songID is not None}
 
         if mod_data:
             for data_dict in mod_data:
@@ -56,6 +62,9 @@ class MegaMixCollections:
                         self.song_items[song_name] = SongData(item_id, song_id, [], False, True, diff_info)
 
         self.item_names_to_id.update({name: data.code for name, data in self.song_items.items()})
+        self.item_name_groups.update({
+            "ModdedSongs": {name for name, data in self.song_items.items() if data.modded}
+        })
 
         for song_name, song_data in self.song_items.items():
             if song_data.code % 2 != 0:  # Fix code for covers

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -32,7 +32,6 @@ class MegaMixCollections:
         self.item_name_groups = {
             "BaseSongs": {name for name, data in self.song_items.items() if not data.modded and not data.DLC},
             "DLCSongs": {name for name, data in self.song_items.items() if not data.modded and data.DLC},
-            "ModdedSongs": {}
         }
 
         self.song_items = SONG_DATA
@@ -62,9 +61,12 @@ class MegaMixCollections:
                         self.song_items[song_name] = SongData(item_id, song_id, [], False, True, diff_info)
 
         self.item_names_to_id.update({name: data.code for name, data in self.song_items.items()})
-        self.item_name_groups.update({
-            "ModdedSongs": {name for name, data in self.song_items.items() if data.modded}
-        })
+
+        modded_group = {name for name, data in self.song_items.items() if data.modded}
+        if modded_group: # test_groups::TestNameGroups::test_item_name_groups_not_empty
+            self.item_name_groups.update({
+                "ModdedSongs": modded_group
+            })
 
         for song_name, song_data in self.song_items.items():
             if song_data.code % 2 != 0:  # Fix code for covers

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -109,9 +109,9 @@ class MegaMixCollections:
             "MEIKOSongs": {name for name, data in base_songs.items() if "MEIKO" in data.singers},
         }
 
-        # Disabled since song_items is shared across all players. Need to filter to player_specific_ids.
-        #modded = {name for name, data in self.song_items.items() if data.modded}
-        #if modded: # test_groups::TestNameGroups::test_item_name_groups_not_empty
-        #    groups.update({"ModdedSongs": modded})
+        # Experimental since all players share this group. Filtered in handle_plando.
+        modded = {name for name, data in self.song_items.items() if data.modded}
+        if modded: # test_groups::TestNameGroups::test_item_name_groups_not_empty
+            groups.update({"ModdedSongs": modded})
 
         return groups

--- a/Options.py
+++ b/Options.py
@@ -1,5 +1,4 @@
-from typing import Dict
-from Options import Toggle, Option, Range, Choice, DeathLink, ItemSet, OptionSet, PerGameCommonOptions, FreeText, Visibility
+from Options import Toggle, Option, Range, Choice, DeathLink, ItemSet, OptionSet, PerGameCommonOptions, FreeText, Visibility, Removed
 from dataclasses import dataclass
 
 
@@ -155,22 +154,18 @@ class IncludeSongs(ItemSet):
     - Difficulty options will be skipped for these songs.
     - If there being too many included songs, songs will be randomly chosen without regard for difficulty.
     - If you want these songs immediately, use start_inventory instead.
-    """
+
+    Use /item_groups in the Client for a list of available song groups."""
     verify_item_name = True
     display_name = "Include Songs"
 
 
 class ExcludeSongs(ItemSet):
-    """Any song listed here will be excluded from being a part of the seed."""
+    """Any song listed here will be excluded from being a part of the seed.
+
+    Use /item_groups in the Client for a list of available song groups."""
     verify_item_name = True
     display_name = "Exclude Songs"
-
-
-class ExcludeSinger(OptionSet):
-    """Songs including singers listed here will not be included. Does not affect any modded songs regardless.
-    Available Singers: Hatsune Miku, Kagamine Rin, Kagamine Len, Megurine Luka, KAITO, MEIKO"""
-    display_name = "Exclude Singer"
-    default = {}
 
 
 class ModData(FreeText):
@@ -196,5 +191,5 @@ class MegaMixOptions(PerGameCommonOptions):
     leek_win_count_percentage: LeeksRequiredPercentage
     include_songs: IncludeSongs
     exclude_songs: ExcludeSongs
-    exclude_singers: ExcludeSinger
+    exclude_singers: Removed
     megamix_mod_data: ModData

--- a/__init__.py
+++ b/__init__.py
@@ -93,14 +93,13 @@ class MegaMixWorld(World):
         # Initial search criteria
         lower_rating_threshold, higher_rating_threshold = self.get_difficulty_range()
         lower_diff_threshold, higher_diff_threshold = self.get_available_difficulties(self.options.song_difficulty_min.value, self.options.song_difficulty_max.value)
-        disallowed_singers = self.options.exclude_singers.value
         self.player_specific_mod_data, player_specific_ids = get_player_specific_ids(self.options.megamix_mod_data.value)
 
         while True:
             # In most cases this should only need to run once
 
             allowed_difficulties = list(range(lower_diff_threshold, higher_diff_threshold + 1))
-            available_song_keys = self.mm_collection.get_songs_with_settings(self.options.allow_megamix_dlc_songs, player_specific_ids, allowed_difficulties, disallowed_singers, lower_rating_threshold, higher_rating_threshold)
+            available_song_keys = self.mm_collection.get_songs_with_settings(self.options.allow_megamix_dlc_songs, player_specific_ids, allowed_difficulties, lower_rating_threshold, higher_rating_threshold)
 
             available_song_keys = self.handle_plando(available_song_keys)
             #print(f"{lower_rating_threshold}~{higher_rating_threshold}* {allowed_difficulties}", len(available_song_keys))

--- a/__init__.py
+++ b/__init__.py
@@ -77,7 +77,7 @@ class MegaMixWorld(World):
 
     item_name_to_id = {name: code for name, code in mm_collection.item_names_to_id.items()}
     location_name_to_id = {name: code for name, code in mm_collection.location_names_to_id.items()}
-    item_name_groups = mm_collection.item_name_groups
+    item_name_groups = mm_collection.get_item_name_groups()
 
     # Working Data
     player_specific_mod_data = {}

--- a/__init__.py
+++ b/__init__.py
@@ -150,7 +150,7 @@ class MegaMixWorld(World):
 
     def create_song_pool(self, available_song_keys: List[str]):
         starting_song_count = self.options.starting_song_count.value
-        additional_song_count = min(len(available_song_keys), self.options.additional_song_count.value)
+        additional_song_count = self.options.additional_song_count.value
         self.random.shuffle(available_song_keys)
 
         # First, we must double-check if the player has included too many guaranteed songs

--- a/__init__.py
+++ b/__init__.py
@@ -77,6 +77,7 @@ class MegaMixWorld(World):
 
     item_name_to_id = {name: code for name, code in mm_collection.item_names_to_id.items()}
     location_name_to_id = {name: code for name, code in mm_collection.location_names_to_id.items()}
+    item_name_groups = mm_collection.item_name_groups
 
     # Working Data
     player_specific_mod_data = {}

--- a/__init__.py
+++ b/__init__.py
@@ -81,6 +81,7 @@ class MegaMixWorld(World):
 
     # Working Data
     player_specific_mod_data = {}
+    player_specific_ids = {}
     victory_song_name: str = ""
     victory_song_id: int
     starting_songs: List[str]
@@ -93,13 +94,13 @@ class MegaMixWorld(World):
         # Initial search criteria
         lower_rating_threshold, higher_rating_threshold = self.get_difficulty_range()
         lower_diff_threshold, higher_diff_threshold = self.get_available_difficulties(self.options.song_difficulty_min.value, self.options.song_difficulty_max.value)
-        self.player_specific_mod_data, player_specific_ids = get_player_specific_ids(self.options.megamix_mod_data.value)
+        self.player_specific_mod_data, self.player_specific_ids = get_player_specific_ids(self.options.megamix_mod_data.value)
 
         while True:
             # In most cases this should only need to run once
 
             allowed_difficulties = list(range(lower_diff_threshold, higher_diff_threshold + 1))
-            available_song_keys = self.mm_collection.get_songs_with_settings(self.options.allow_megamix_dlc_songs, player_specific_ids, allowed_difficulties, lower_rating_threshold, higher_rating_threshold)
+            available_song_keys = self.mm_collection.get_songs_with_settings(self.options.allow_megamix_dlc_songs, self.player_specific_ids, allowed_difficulties, lower_rating_threshold, higher_rating_threshold)
 
             available_song_keys = self.handle_plando(available_song_keys)
             #print(f"{lower_rating_threshold}~{higher_rating_threshold}* {allowed_difficulties}", len(available_song_keys))
@@ -141,8 +142,11 @@ class MegaMixWorld(World):
         include_songs = self.options.include_songs.value
         exclude_songs = self.options.exclude_songs.value
 
-        self.starting_songs = [s for s in start_items if s in song_items]
-        self.included_songs = [s for s in include_songs if s in song_items and s not in self.starting_songs]
+        # The ModdedSongs group is shared across all players. Limit to own songs.
+        self.starting_songs = [s for s in start_items if s in song_items and
+                               not song_items.get(s).modded or song_items.get(s).songID in self.player_specific_ids]
+        self.included_songs = [s for s in include_songs if s in song_items and s not in self.starting_songs and
+                               not song_items.get(s).modded or song_items.get(s).songID in self.player_specific_ids]
 
         return [s for s in available_song_keys if s not in start_items
                 and s not in include_songs and s not in exclude_songs]

--- a/test/TestNoModsCaseSettings.py
+++ b/test/TestNoModsCaseSettings.py
@@ -12,7 +12,7 @@ class TestWorstCaseTest(MegaMixTestBase):
         "allow_megamix_dlc_songs": True,
         "song_difficulty_min": 'easy',
         "song_difficulty_max": 'exextreme',
-        "include_songs": ["DYE", "Gizmo", "Kokoro"],
-        "exclude_songs": ["2D Dream Fever", "Break It, Break It!", "Change Me"],
+        "include_songs": ["DYE [603]", "Gizmo [442]", "Kokoro [55]"],
+        "exclude_songs": ["2D Dream Fever [723]", "Break It, Break It! [734]", "Change Me [59]"],
         "megamix_mod_data": '',
     }

--- a/test/TestWorstCaseSettings.py
+++ b/test/TestWorstCaseSettings.py
@@ -12,7 +12,7 @@ class TestWorstCaseTest(MegaMixTestBase):
         "allow_megamix_dlc_songs": True,
         "song_difficulty_min": 'easy',
         "song_difficulty_max": 'exextreme',
-        "include_songs": ["DYE", "Gizmo", "Kokoro"],
-        "exclude_songs": ["2D Dream Fever", "Break It, Break It!", "Change Me"],
+        "include_songs": ["DYE [603]", "Gizmo [442]", "Kokoro [55]"],
+        "exclude_songs": ["2D Dream Fever [723]", "Break It, Break It! [734]", "Change Me [59]"],
         "megamix_mod_data": '{"alocin PPD Song Pack":[["Bad Shark",4950,22240],["Dare da Omae",4951,6400],["Esper Esper",4952,22816],["Flyer!",4953,7936],["Hoshi o Tsunagu",4954,23296],["Hyuudoro",4955,23296],["IF",4956,6400],["JUMPIN'' OVER!",4957,6400],["Kuu ni Naru",4958,21760],["Metamo Re:born",4959,23264],["Pikapika",4960,7456],["Snow Mile",4961,6368],["STAGE OF SEKAI",4962,7936],["What Kind of Future",4963,7936],["Whatever Yama Says Goes",4964,288],["Jidanda Beat",4965,288],["HAO",4966,768]]}',
     }

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -105,7 +105,7 @@ class TestOptionExcludeItemGroups(MegaMixTestBase):
         "additional_song_count": 251,
     }
 
-    def test_exclude_singer_group(self):
+    def test_exclude_group(self):
         # mmc/group_songs could be initialized once outside the test class?
         mmc = MegaMixCollections()
         group_songs = mmc.get_item_name_groups()[self.group]

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -2,6 +2,7 @@ from typing import ClassVar
 
 from test.param import classvar_matrix
 from . import MegaMixTestBase
+from ..MegaMixCollection import MegaMixCollections
 
 # WARNING: mm_collection.song_items is subject to available megamix_mod_data from Players YAMLs during all tests.
 # When testing locally this may affect length checks.
@@ -93,27 +94,29 @@ class TestOptionExcludes(MegaMixTestBase):
         self.assertFalse(world.options.exclude_songs.value.issubset(pool))
 
 
-# Can also supply combinations.
-@classvar_matrix(singer=[{'Hatsune Miku'}, {'Kagamine Rin'}, {'Kagamine Len'}, {'Megurine Luka'}, {'KAITO'}, {'MEIKO'}])
-class TestOptionExcludeSinger(MegaMixTestBase):
-    """Set exclude_singers and test the multiworld item pool for their absence."""
-    auto_construct = False
-    singer: ClassVar[set[str]]
+@classvar_matrix(group=['MikuSongs', 'RinSongs', 'LenSongs', 'LukaSongs', 'KAITOSongs', 'MEIKOSongs', 'BaseSongs', 'DLCSongs'])
+class TestOptionExcludeItemGroups(MegaMixTestBase):
+    """Set exclude_songs to an item group and test the multiworld item pool for their absence.
+    The classvar solution was elegant before resolving item groups manually. Something probably went wrong somewhere."""
+    auto_construct = False # Big time saver since the initial gen is thrown out
+    group: ClassVar[str]
     options = {
         "allow_megamix_dlc_songs": True,
         "additional_song_count": 251,
     }
 
-    def test_exclude_singer(self):
-        self.options["exclude_singers"] = self.singer
+    def test_exclude_singer_group(self):
+        # mmc/group_songs could be initialized once outside the test class?
+        mmc = MegaMixCollections()
+        group_songs = mmc.get_item_name_groups()[self.group]
+        self.options["exclude_songs"] = group_songs
         self.world_setup()
 
         world = self.get_world()
-        singer_songs = [song for song, prop in self.world.mm_collection.song_items.items() if set(prop.singers).intersection(world.options.exclude_singers)]
         pool = {song.name for song in self.world.multiworld.itempool if song.code >= 10}
         pool.update(world.starting_songs)
         pool.add(world.victory_song_name)
 
-        intersect = pool.intersection(singer_songs)
-        self.assertEqual(0, len(intersect), f"0 songs from {world.options.exclude_singers} expected, got {len(intersect)}: {intersect}")
-        self.assertEqual(len(singer_songs) + len(pool), len(self.world.mm_collection.song_items))
+        intersect = pool.intersection(group_songs)
+        self.assertEqual(0, len(intersect), f"0 songs from {self.group} expected, got {len(intersect)}: {intersect}")
+        self.assertEqual(len(group_songs) + len(pool), len(self.world.mm_collection.song_items))

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -2,7 +2,6 @@ from typing import ClassVar
 
 from test.param import classvar_matrix
 from . import MegaMixTestBase
-from ..MegaMixCollection import MegaMixCollections
 
 # WARNING: mm_collection.song_items is subject to available megamix_mod_data from Players YAMLs during all tests.
 # When testing locally this may affect length checks.

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -96,9 +96,8 @@ class TestOptionExcludes(MegaMixTestBase):
 
 @classvar_matrix(group=['MikuSongs', 'RinSongs', 'LenSongs', 'LukaSongs', 'KAITOSongs', 'MEIKOSongs', 'BaseSongs', 'DLCSongs'])
 class TestOptionExcludeItemGroups(MegaMixTestBase):
-    """Set exclude_songs to an item group and test the multiworld item pool for their absence.
-    The classvar solution was elegant before resolving item groups manually. Something probably went wrong somewhere."""
-    auto_construct = False # Big time saver since the initial gen is thrown out
+    """Set exclude_songs to an item group and test the multiworld item pool for their absence."""
+    run_default_tests = False # Greatly speeds up testing time
     group: ClassVar[str]
     options = {
         "allow_megamix_dlc_songs": True,
@@ -106,16 +105,13 @@ class TestOptionExcludeItemGroups(MegaMixTestBase):
     }
 
     def test_exclude_group(self):
-        # mmc/group_songs could be initialized once outside the test class?
-        mmc = MegaMixCollections()
-        group_songs = mmc.get_item_name_groups()[self.group]
+        group_songs = self.world.item_name_groups[self.group]
         self.options["exclude_songs"] = group_songs
         self.world_setup()
 
-        world = self.get_world()
         pool = {song.name for song in self.world.multiworld.itempool if song.code >= 10}
-        pool.update(world.starting_songs)
-        pool.add(world.victory_song_name)
+        pool.update(self.world.starting_songs)
+        pool.add(self.world.victory_song_name)
 
         intersect = pool.intersection(group_songs)
         self.assertEqual(0, len(intersect), f"0 songs from {self.group} expected, got {len(intersect)}: {intersect}")


### PR DESCRIPTION
- [x] ~~Blocked by #60 since it's around the same area in MMC. This should be merged after that to check for conflicts.~~
- [x] ~~Blocked by #58. The `exclude_singers` test will need to be updated.~~ Painful.

Adds the following item groups:
- BaseSongs
- DLCSongs
- ModdedSongs
  - Experimental, filtering done in `handle_plando` so players can't get songs they don't have.
- MikuSongs/RinSongs/LenSongs/LukaSongs/KAITOSongs/MEIKOSongs
  - Leia and Luka Luka Night Fever were addressed in #60
  - ~~This can obsolete the `exclude_singers` option while also providing an `include_singers` alternative.~~ Done!
  - Modded would be possible if included in the export. Out of scope here.

Archipelago's Generator expands these so `BaseSongs` becomes `Love is War [1], World is Mine [2], etc` when used in `include_songs` and `exclude_songs`. No extra effort needed. These also expand in the Client when using `!hint BaseSongs`.

Other potential groups:
 - Individual song packs

Location groups *are* possible but offer few benefits over `exclude_songs` to be worthwhile.