### PR TITLE
Client: Restore on shutdown/close

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -371,7 +371,7 @@ class MegaMixContext(CommonContext):
             logger.info("Removed non-AP songs!")
 
     async def restore_songs(self):
-        mod_pv_dbs = [f"{root}\mod_pv_db.txt" for root, _, files in os.walk(self.path) if 'mod_pv_db.txt' in files]
+        mod_pv_dbs = [f"{root}/mod_pv_db.txt" for root, _, files in os.walk(self.path) if 'mod_pv_db.txt' in files]
         restore_originals(mod_pv_dbs)
 
     async def shutdown(self):

--- a/Client.py
+++ b/Client.py
@@ -371,8 +371,7 @@ class MegaMixContext(CommonContext):
             logger.info("Removed non-AP songs!")
 
     async def restore_songs(self):
-        mod_pv_dbs = [os.path.join(self.path, pack, "rom", "mod_pv_db.txt") for pack in os.listdir(self.path) if
-                      os.path.isfile(os.path.join(self.path, pack, "rom", "mod_pv_db.txt"))]
+        mod_pv_dbs = [f"{root}\mod_pv_db.txt" for root, _, files in os.walk(self.path) if 'mod_pv_db.txt' in files]
         restore_originals(mod_pv_dbs)
 
     async def shutdown(self):

--- a/Client.py
+++ b/Client.py
@@ -63,8 +63,9 @@ class MegaMixContext(CommonContext):
 
         self.game = "Hatsune Miku Project Diva Mega Mix+"
         self.path = settings.get_settings()["megamix_options"]["mod_path"]
-        self.mod_pv = self.path + "/ArchipelagoMod/rom/mod_pv_db.txt"
-        self.songResultsLocation = self.path + "/ArchipelagoMod/results.json"
+        self.mod_name = "ArchipelagoMod"
+        self.mod_pv = f"{self.path}/{self.mod_name}/rom/mod_pv_db.txt"
+        self.songResultsLocation = f"{self.path}/{self.mod_name}/results.json"
         self.modData = None
         self.modded = False
         self.freeplay = False
@@ -370,7 +371,13 @@ class MegaMixContext(CommonContext):
             logger.info("Removed non-AP songs!")
 
     async def restore_songs(self):
-        restore_originals(self.mod_pv_list)
+        mod_pv_dbs = [os.path.join(self.path, pack, "rom", "mod_pv_db.txt") for pack in os.listdir(self.path) if
+                      os.path.isfile(os.path.join(self.path, pack, "rom", "mod_pv_db.txt"))]
+        restore_originals(mod_pv_dbs)
+
+    async def shutdown(self):
+        await self.restore_songs()
+        await super().shutdown()
 
 
 def launch():

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -1,6 +1,5 @@
 import json
 import yaml
-import pkgutil
 import re
 import os
 import shutil
@@ -8,7 +7,7 @@ import sys
 import settings
 import Utils
 import logging
-from .SymbolFixer import fix_song_name
+import filecmp
 from typing import Any
 
 # Set up logger
@@ -57,8 +56,11 @@ def restore_originals(original_file_paths):
         copy_file_path = os.path.join(directory, copy_filename)
 
         if os.path.exists(copy_file_path):
-            shutil.copyfile(copy_file_path, original_file_path)
-            logger.debug(f"Restored {original_file_path} from {copy_file_path}")
+            if not filecmp.cmp(copy_file_path, original_file_path):
+                shutil.copyfile(copy_file_path, original_file_path)
+                logger.debug(f"Restored {original_file_path} from {copy_file_path}")
+            else:
+                logger.debug(f"Skipping restore on {original_file_path} (matches copy)")
         else:
             logger.debug(f"The copy file {copy_file_path} does not exist.")
 


### PR DESCRIPTION
The first last step in a potentially generic pack un/locking system for this iteration of the Client.

Sometimes I connect to a room to test. The Client sets up the pv_dbs, I do my testing, close the Client. I open the game later to play casually and it's still in the room state.

Instead of relying on `self.mod_pv_list`, the function generates a list of *all* potential `mod_pv_db.txt` including the AP mod's. It does not require a room connection or valid mod data in the slot data (i.e. renamed folders).

A small consideration has been made to minimize write amplification since I don't trust *shutil* on its own. [Docs](https://docs.python.org/3/library/shutil.html) say "in the most efficient way possible" but I can't pin down if that means not copying at all if they are the exact same file (not path). This compounds WA reductions when restore on goal happens and the Client is eventually closed.