### PR TITLE
init+Client: Universal Tracker support

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -22,6 +22,12 @@ from CommonClient import (
     server_loop,
     gui_enabled,
 )
+tracker_loaded = False
+try:
+    from worlds.tracker.TrackerClient import TrackerGameContext as SuperContext
+    tracker_loaded = True
+except ModuleNotFoundError:
+    from CommonClient import CommonContext as SuperContext
 from NetUtils import NetworkItem, ClientStatus, Permission
 
 
@@ -53,10 +59,11 @@ class DivaClientCommandProcessor(ClientCommandProcessor):
         logger.info("Base Game + Mod Packs Restored")
 
 
-class MegaMixContext(CommonContext):
+class MegaMixContext(SuperContext):
     """MegaMix Game Context"""
 
     command_processor = DivaClientCommandProcessor
+    tags = {"AP"}
 
     def __init__(self, server_address: Optional[str], password: Optional[str]) -> None:
         super().__init__(server_address, password)
@@ -108,6 +115,7 @@ class MegaMixContext(CommonContext):
         await self.send_connect()
 
     def on_package(self, cmd: str, args: dict):
+        super().on_package(cmd, args) # Universal Tracker
 
         if cmd == "Connected":
 
@@ -384,6 +392,8 @@ def launch():
         """
         ctx = MegaMixContext(args.connect, args.password)
         ctx.server_task = asyncio.create_task(server_loop(ctx), name="server loop")
+        if tracker_loaded:
+            ctx.run_generator()
         if gui_enabled:
             ctx.run_gui()
         ctx.run_cli()

--- a/__init__.py
+++ b/__init__.py
@@ -280,10 +280,8 @@ class MegaMixWorld(World):
         self.random.shuffle(included_song_copy)
         all_selected_locations.extend(included_song_copy)
 
-        # Make a region per song/album, then adds 1-2 item locations to them
-        for i in range(0, len(all_selected_locations)):
-            name = all_selected_locations[i]
-
+        # Adds 2 item locations per song/album to the menu region.
+        for name in all_selected_locations:
             for j in range(2):
                 loc = MegaMixLocation(self.player, f"{name}-{j}", self.mm_collection.song_locations[f"{name}-{j}"], menu_region)
                 loc.access_rule = lambda state, place=name: state.has(place, self.player)

--- a/__init__.py
+++ b/__init__.py
@@ -98,10 +98,8 @@ class MegaMixWorld(World):
 
             if "finalSongIDs" in slot_data:
                 final = slot_data.get("finalSongIDs", [])
-                songs = [key for key, song in self.mm_collection.song_items.items() if song.songID in final]
-
-                self.included_songs = songs
-                self.location_count = len(songs) * 2
+                self.included_songs = [key for key, song in self.mm_collection.song_items.items() if song.songID in final]
+                self.location_count = len(self.included_songs) * 2
             return
 
         # Initial search criteria
@@ -268,9 +266,7 @@ class MegaMixWorld(World):
 
     def create_regions(self) -> None:
         menu_region = Region("Menu", self.player, self.multiworld)
-        song_select_region = Region("Song Select", self.player, self.multiworld)
-        self.multiworld.regions += [menu_region, song_select_region]
-        menu_region.connect(song_select_region)
+        self.multiworld.regions += [menu_region]
 
         # Make a collection of all songs available for this rando.
         # 1. All starting songs
@@ -287,16 +283,11 @@ class MegaMixWorld(World):
         # Make a region per song/album, then adds 1-2 item locations to them
         for i in range(0, len(all_selected_locations)):
             name = all_selected_locations[i]
-            region = Region(name, self.player, self.multiworld)
-            self.multiworld.regions.append(region)
-            song_select_region.connect(region, name, lambda state, place=name: state.has(place, self.player))
 
-            locations = {}
             for j in range(2):
-                location_name = f"{name}-{j}"
-                locations[location_name] = self.mm_collection.song_locations[location_name]
-
-            region.add_locations(locations, MegaMixLocation)
+                loc = MegaMixLocation(self.player, f"{name}-{j}", self.mm_collection.song_locations[f"{name}-{j}"], menu_region)
+                loc.access_rule = lambda state, place=name: state.has(place, self.player)
+                menu_region.locations.append(loc)
 
     def set_rules(self) -> None:
         self.multiworld.completion_condition[self.player] = lambda state: \

--- a/__init__.py
+++ b/__init__.py
@@ -280,7 +280,7 @@ class MegaMixWorld(World):
         self.random.shuffle(included_song_copy)
         all_selected_locations.extend(included_song_copy)
 
-        # Adds 2 item locations per song/album to the menu region.
+        # Adds 2 item locations per song to the menu region.
         for name in all_selected_locations:
             for j in range(2):
                 loc = MegaMixLocation(self.player, f"{name}-{j}", self.mm_collection.song_locations[f"{name}-{j}"], menu_region)

--- a/__init__.py
+++ b/__init__.py
@@ -86,7 +86,7 @@ class MegaMixWorld(World):
     victory_song_name: str = ""
     victory_song_id: int
     starting_songs: List[str] = []
-    included_songs: List[str] = []
+    included_songs: List[str]
     final_song_ids: set[int] = set()
     needed_token_count: int
     location_count: int
@@ -284,7 +284,7 @@ class MegaMixWorld(World):
         for name in all_selected_locations:
             for j in range(2):
                 loc = MegaMixLocation(self.player, f"{name}-{j}", self.mm_collection.song_locations[f"{name}-{j}"], menu_region)
-                loc.access_rule = lambda state, place=name: state.has(place, self.player)
+                loc.access_rule = lambda state, item=name: state.has(item, self.player)
                 menu_region.locations.append(loc)
 
     def set_rules(self) -> None:


### PR DESCRIPTION
Like the leek label, not intended to replace `/uncleared`. Just for Universal Tracker users.

- [x] Tracker Client support (`Launcher.py "Universal Tracker"`)
- [x] Tracker tab in Mega Mix Client (`Launcher.py "Mega Mix Client"`, screenshot)
- [x] Works with multiple modded players (sharing the same room/world datapackage) 
- [ ] ~~Cleaner final_song_ids (currently done in `create_item()`)~~

Caveats:
- Cannot differentiate between a received song/item classified as progression or useful.
  - The problem is *not* not knowing during UT regen which songs would get a dupe, but which one was received from the MW as the only difference is the on-the-fly classification.
  - Not worth fixing and what is a player supposed to do, not play the song?
- Cannot indicate the goal song without creating a region/locations for it. (not worth) 
- Dynamic datapackage breaks local UT gen with received [missing/unknown songs.](https://github.com/FarisTheAncient/Archipelago/blob/6e737b73ad771c83f5e4be1daa36da3f2e9ed69c/worlds/tracker/TrackerCore.py#L301)
  - TLDR: A player's relevant `megamix_mod_data` must be available. At least enough to satisfy UT.
  - If enough partial `megamix_mod_data` is available UT will [warn about the mismatch instead.](https://github.com/FarisTheAncient/Archipelago/blob/6e737b73ad771c83f5e4be1daa36da3f2e9ed69c/worlds/tracker/TrackerClient.py#L875-L876)
  - 4681 waiting room
- Not passing [fuzzer hook](https://github.com/FarisTheAncient/Archipelago/blob/Tracker_v0.2.15/worlds/tracker/fuzzer_hook.py)
  - `fuzz.py -g megamix -r 100 --hook worlds.tracker.fuzzer_hook:Hook`
  - Does pass n2+ `fuzz.py -g megamix -r 100 -n 2 --hook worlds.tracker.fuzzer_hook:Hook`

<img width="420" height="422" alt="image" src="https://github.com/user-attachments/assets/00d32d92-75c3-4a7a-a229-3dc48aa535b6" />