### PR TITLE
Options: Introduce groups and WebWorld

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1,4 +1,5 @@
-from Options import Toggle, Option, Range, Choice, DeathLink, ItemSet, OptionSet, PerGameCommonOptions, FreeText, Visibility, Removed
+from Options import Toggle, Option, Range, Choice, DeathLink, ItemSet, OptionSet, PerGameCommonOptions, FreeText, \
+    Visibility, Removed, OptionGroup
 from dataclasses import dataclass
 
 
@@ -173,6 +174,23 @@ class ModData(FreeText):
     display_name = "MegaMixModData"
     default = ''
     visibility = Visibility.template | Visibility.spoiler
+
+
+megamix_option_groups = [
+    OptionGroup("Song Choice", [
+        AllowMegaMixDLCSongs,
+        IncludeSongs,
+        ExcludeSongs,
+        ModData, # hidden by visibility property
+    ]),
+    OptionGroup("Difficulty", [
+        ScoreGradeNeeded,
+        DifficultyModeMin,
+        DifficultyModeMax,
+        DifficultyRatingMin,
+        DifficultyRatingMax,
+    ]),
+]
 
 
 @dataclass

--- a/Options.py
+++ b/Options.py
@@ -176,7 +176,7 @@ class ModData(FreeText):
     default = ''
     visibility = Visibility.template | Visibility.spoiler
 
- 
+
 class DivaDeathLink(DeathLink):
     """When you die on your own or fail to reach Grade Needed (not both), everyone who enabled Death Link dies.
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,12 +1,12 @@
 #AP
-from worlds.AutoWorld import World
+from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
 from BaseClasses import Region, Item, ItemClassification, Entrance, Tutorial, MultiWorld
 from Options import PerGameCommonOptions
 import settings
 
 #Local
-from .Options import MegaMixOptions
+from .Options import MegaMixOptions, megamix_option_groups
 from .Items import MegaMixSongItem, MegaMixFixedItem
 from .Locations import MegaMixLocation
 from .MegaMixCollection import MegaMixCollections
@@ -56,6 +56,10 @@ class MegaMixSettings(settings.Group):
     mod_path: ModPath = ModPath("C:/Program Files (x86)/Steam/steamapps/common/Hatsune Miku Project DIVA Mega Mix Plus/mods")
 
 
+class MegaMixWebWorld(WebWorld):
+    theme = "ocean"
+    option_groups = megamix_option_groups
+
 class MegaMixWorld(World):
     """Hatsune Miku: Project Diva Mega Mix+ is a rhythm game where you hit notes to the beat of one of 250+ songs.
     Play through a selection of randomly chosen songs, collecting leeks
@@ -69,6 +73,7 @@ class MegaMixWorld(World):
     options: MegaMixOptions
 
     topology_present = False
+    web = MegaMixWebWorld()
 
     # Necessary Data
     mm_collection = MegaMixCollections()


### PR DESCRIPTION
- [ ] Waiting on #56 and #68 to rebase

Not specifically *for* use in a web browser but the 3 people who run a webhost with MM+ will appreciate this.

`megamix_mod_data` is still properly hidden on webhost despite being listed in the group.

The groups also appear in template YAMLs in recent versions of Archipelago:
```YAML
  ###############
  # Song Choice #
  ###############
  allow_megamix_dlc_songs:
    # Whether Extra Song Pack DLC Songs can be chosen as randomised songs.
    'false': 50
    'true': 0

  include_songs:
    # ...
  ```