### PR TITLE
jsonmm: various fixes

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -164,13 +164,17 @@ def extract_mod_data_to_json() -> list[Any]:
 
                         # Process each mod_data block
                         for _ in matches:
-                            for single_yaml in yaml.safe_load_all(file_content):
-                                mod_data_content = single_yaml.get("Hatsune Miku Project Diva Mega Mix+", {}).get("megamix_mod_data", None)
+                            try:
+                                for single_yaml in yaml.safe_load_all(file_content):
+                                    mod_data_content = single_yaml.get("Hatsune Miku Project Diva Mega Mix+", {}).get("megamix_mod_data", None)
 
-                                if isinstance(mod_data_content, dict) or not mod_data_content:
-                                    continue
+                                    if isinstance(mod_data_content, dict) or not mod_data_content:
+                                        continue
 
-                                all_mod_data.append(json.loads(mod_data_content))
+                                    print(mod_data_content)
+                                    all_mod_data.append(json.loads(mod_data_content))
+                            except Exception as e:
+                                logger.warning(f"Failed to extract mod data from {item}\n{e}")
 
     total = sum(len(pack) for packList in all_mod_data for pack in packList.values())
     logger.debug(f"Found {total} songs")

--- a/__init__.py
+++ b/__init__.py
@@ -26,7 +26,6 @@ def launch_client():
 
 components.append(Component(
     "Mega Mix Client",
-    "MegaMixClient",
     func=launch_client,
     component_type=Type.CLIENT
 ))
@@ -39,7 +38,6 @@ def launch_json_generator():
 
 components.append(Component(
     "Mega Mix JSON Generator",
-    "MegamixJSONGenerator",
     func=launch_json_generator,
     component_type=Type.ADJUSTER
 ))

--- a/generator_megamix/json_megamix.py
+++ b/generator_megamix/json_megamix.py
@@ -58,7 +58,7 @@ def process_single_mod(mod_pv_db_path: str, mod_dir: str) -> tuple[set[int], lis
         mod_pv_db = input_file.read()
     mod_pv_db = set(re.findall(rf'^(?:#ARCH#)?pv_(\d+)\.(song_name_en|difficulty)(?:\.([^.]+)\.(\d|length)\.?(level|script_file_name|attribute\.extra)?)?=(.*)$', mod_pv_db, re.MULTILINE))
 
-    for line in mod_pv_db:
+    for line in sorted(mod_pv_db):
         song_id, song_prop, diff_rating, diff_index_length, diff_prop, value = line
         songs.setdefault(song_id, ["", int(song_id), 0])
         diff_lockout.setdefault(song_id, [False] * 5)
@@ -85,8 +85,9 @@ def process_single_mod(mod_pv_db_path: str, mod_dir: str) -> tuple[set[int], lis
                 match diff_prop:
                     case "level" if not diff_lockout[song_id][diff_index]:
                         songs[song_id][2] = shift_difficulty(songs[song_id][2], diff_index, float(".".join(value.split("_")[2:4])))
-                    case "script_file_name" if song_id not in base_game_ids: # 99% covers. Good luck everyone.
+                    case "script_file_name" if int(song_id) not in base_game_ids: # 99% covers. Good luck everyone.
                         if not os.path.isfile(os.path.join(mod_dir, value)): # Verify DSC exists
+                            print(f"{song_id} No {difficulties[diff_index]} DSC at {value}")
                             diff_lockout[song_id][diff_index] = True
                             songs[song_id][2] = shift_difficulty(songs[song_id][2], diff_index, 31.0)
 


### PR DESCRIPTION
- Fix a string vs int comparison
  -  Fixes Eden Core and other official song covers difficulty data
    - Not a fix for actually using covers
- Print out a DSC miss instead of wondering why part/all of the difficulty field is 0
- Sort the for loop so the output arrays are in order
  - Originally I did not care, but looking through mod data before was painful when 1234 was not followed by 1235
- `try` the mod string extraction to not brick the world with bad YAMLs
- Remove `script_name`s in launcher components