### PR TITLE
Switch from selecting mod folder to game exe

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -4,8 +4,8 @@ import colorama
 import os
 import json
 import time
-import settings
 from .DataHandler import (
+    game_paths,
     load_json_file,
     erase_song_list,
     song_unlock,
@@ -73,7 +73,7 @@ class MegaMixContext(SuperContext):
         super().__init__(server_address, password)
 
         self.game = "Hatsune Miku Project Diva Mega Mix+"
-        self.path = settings.get_settings()["megamix_options"]["mod_path"]
+        self.path = game_paths().get("mods")
         self.mod_name = "ArchipelagoMod"
         self.mod_pv = f"{self.path}/{self.mod_name}/rom/mod_pv_db.txt"
         self.songResultsLocation = f"{self.path}/{self.mod_name}/results.json"

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 def game_paths() -> dict[str, str]:
     """Build relevant paths based on the game exe and, if available, the mod loader config."""
+
     exe_path = settings.get_settings()["megamix_options"]["game_exe"]
     game_path = os.path.dirname(exe_path)
     mods_path = os.path.join(game_path, "mods")

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -26,7 +26,7 @@ def game_paths() -> dict[str, str]:
     dml_config = os.path.join(game_path, "config.toml")
     if os.path.isfile(dml_config):
         with open(dml_config, "r") as f:
-            mod_line = re.search(r"""^mods\s*=\s*['"](.*?)['"]""", f.read(), re.MULTILINE)
+            mod_line = re.search(r"""^mods\s*=\s*['"](.*?)['"]""", f.read())
             if mod_line:
                 mods_path = os.path.join(game_path, mod_line.group(1))
 

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -8,7 +8,7 @@ import settings
 import Utils
 import logging
 import filecmp
-from typing import Any, Dict
+from typing import Any
 
 # Set up logger
 logging.basicConfig(level=logging.DEBUG)

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -8,11 +8,33 @@ import settings
 import Utils
 import logging
 import filecmp
-from typing import Any
+from typing import Any, Dict
 
 # Set up logger
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
+
+
+def game_paths() -> dict[str, str]:
+    """Build relevant paths based on the game exe and, if available, the mod loader config."""
+    exe_path = settings.get_settings()["megamix_options"]["game_exe"]
+    game_path = os.path.dirname(exe_path)
+    mods_path = os.path.join(game_path, "mods")
+
+    # Seemingly no TOML parser in frozen AP
+    dml_config = os.path.join(game_path, "config.toml")
+    if os.path.isfile(dml_config):
+        with open(dml_config, "r") as f:
+            mod_line = re.search(r"""^mods\s*=\s*['"](.*?)['"]""", f.read(), re.MULTILINE)
+            if mod_line:
+                mods_path = os.path.join(game_path, mod_line.group(1))
+
+    return {
+        "exe": exe_path,
+        "game": game_path,
+        "mods": mods_path
+    }
+
 
 # File Handling
 def load_json_file(file_name: str) -> dict:

--- a/__init__.py
+++ b/__init__.py
@@ -43,15 +43,17 @@ components.append(Component(
 ))
 
 class MegaMixSettings(settings.Group):
-    class ModPath(settings.LocalFolderPath):
+    class GameExe(settings.LocalFilePath):
         """
-        Mod folder location for Hatsune Miku Project DIVA Mega Mix+. Usually ends with "/mods".
+        Path to the HMPDMM+'s game exe. Usually ends with "DivaMegaMix.exe"
         Players (Mega Mix Clients) must have this set correctly in THEIR host.yaml.
         Generating and hosting do not rely on this.
         """
-        description = "Hatsune Miku Project DIVA Mega Mix+ mods folder"
+        description = "Hatsune Miku Project DIVA Mega Mix+ game executable"
+        is_exe = True
+        md5s = ["813e1befae1776d4fafdf907e509b28b"] # 1.03
 
-    mod_path: ModPath = ModPath("C:/Program Files (x86)/Steam/steamapps/common/Hatsune Miku Project DIVA Mega Mix Plus/mods")
+    game_exe: GameExe = GameExe("C:/Program Files (x86)/Steam/steamapps/common/Hatsune Miku Project DIVA Mega Mix Plus/DivaMegaMix.exe")
 
 
 class MegaMixWebWorld(WebWorld):

--- a/generator_megamix/generator.py
+++ b/generator_megamix/generator.py
@@ -15,7 +15,7 @@ import Utils
 import settings
 from .json_megamix import process_mods, ConflictException
 from .. import MegaMixWorld
-from ..DataHandler import restore_originals
+from ..DataHandler import restore_originals, game_paths
 
 
 class AssociatedMDLabel(MDLabel):
@@ -38,7 +38,7 @@ class DivaJSONGenerator(ThemedApp):
     pack_list_scroll: ScrollBox = ObjectProperty(None)
     filter_input: MDTextField = ObjectProperty(None)
 
-    mods_folder = settings.get_settings()["megamix_options"]["mod_path"]
+    mods_folder = game_paths().get("mods")
     self_mod_name = "ArchipelagoMod" # Hardcoded. Fetch from Client or something.
     labels = []
 


### PR DESCRIPTION
Should resolve 99% of issues involving the mods folder selection... by getting rid of it. It's been simplified to only selecting the game exe and building the rest of the paths needed based on it.

 - If the mod loader config is available, attempt to use the defined `mods` path.
   - Seemingly frozen AP has no TOML parser so it's done manually.
   - Currently a simple path join. DML seems to only operate on relative/local paths so this should be fine.
 - Can check for local game files, i.e. `diva_dlc00.cpk`. Not as fancy as existing DLL solutions but it's something.

Selecting the correct `DivaMegaMix.exe` is *required* as it's matched against the 1.03 MD5. This only affects the Client and JSON generator so *generating* a multiworld does not ask for it.