### PR TITLE
generator: hide all AP from selection

### DIFF
--- a/generator_megamix/generator.py
+++ b/generator_megamix/generator.py
@@ -54,7 +54,7 @@ class DivaJSONGenerator(ThemedApp):
 
             folder_name = str(Path(root).parent.relative_to(mods_folder))
 
-            if folder_name == self.self_mod_name:
+            if folder_name.startswith(self.self_mod_name):
                 continue
 
             self.pack_list_scroll.layout.add_widget(self.create_pack_line(folder_name))


### PR DESCRIPTION
With the switch to handle individual song folders *then* chasing it up by converting the mod to do the same this slipped through.

Before, it was possible to select `ArchipelagoMod\AP` and put the BK song into the pool. As awesome as that sounds it serves a specific purpose of always being enabled.