### PR TITLE
init: require YAML for UT

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -85,7 +85,6 @@ class MegaMixWorld(World):
 
     topology_present = False
     web = MegaMixWebWorld()
-    ut_can_gen_without_yaml = False
 
     # Necessary Data
     mm_collection = MegaMixCollections()


### PR DESCRIPTION
It's simpler to have it fail internal generation all the time instead of explaining that modded songs need the YAML in place otherwise it fails to connect to the room.

The world *could* generate YAMLless if only base songs are part of the seed. Now it can't. Thanks modded players.