### PR TITLE
tests: retain apq for test/general

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Archipelago | Setup
         run: |
-          find ./worlds -mindepth 1 -maxdepth 1 -type d -regextype posix-extended ! -regex '.*/(megamix|generic|alttp)' -exec rm -rf {} \;
+          find ./worlds -mindepth 1 -maxdepth 1 -type d -regextype posix-extended ! -regex '.*/(megamix|generic|alttp|apquest)' -exec rm -rf {} \;
           uv venv
           uv pip install pip pytest pytest-subtests pytest-xdist
           find -name requirements.txt | xargs -n1 uv pip install -r


### PR DESCRIPTION
At the time of writing `test/general/test_options.py::TestOptions::test_item_links_name_group` has a hard dependency on APQuest being present, so keep it.