### PR TITLE
Client: Safe Mode

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -53,18 +53,16 @@ class DivaClientCommandProcessor(ClientCommandProcessor):
         """Toggle that restores or removes songs that aren't part of this AP run"""
         asyncio.create_task(self.ctx.freeplay_toggle())
 
-    def _cmd_restore_songs(self):
-        """Restore songs to their pre-Archipelago state, automatic on release or Client close
-        Use as a failsafe for songs not appearing and play on the honor system"""
-        logger.info("Restoring..")
-        asyncio.create_task(self.ctx.restore_songs())
-        logger.info("Base Game + Mod Packs Restored")
-
     def _cmd_deathlink(self, amnesty = ""):
         """Toggle Death Link on and off or provide a number >= 0 to change Amnesty.
         Lethality can be adjusted in the mod's config.toml"""
         asyncio.create_task(self.ctx.toggle_deathlink(amnesty))
 
+    def _cmd_safe_mode(self, out_of_logic = ""):
+        """Toggle safe mode for covers, lyrics, New Classics, etc.
+        All songs will be visible. The AP mod can be the lowest priority in this mode.
+        Prevents out of logic by default. Provide any text to allow."""
+        asyncio.create_task(self.ctx.toggle_safe_mode(out_of_logic))
 
 class MegaMixContext(SuperContext):
     """MegaMix Game Context"""
@@ -90,6 +88,8 @@ class MegaMixContext(SuperContext):
         self.freeplay = False
         self.mod_pv_list = []
         self.sent_unlock_message = False
+        self.safe_mode = False
+        self.safe_mode_strict = True
 
         self.items_handling = 0b001 | 0b010 | 0b100  #Receive items from other worlds, starting inv, and own items
         self.location_ids = None
@@ -186,7 +186,8 @@ class MegaMixContext(SuperContext):
             self.item_name_to_ap_id = args["data"]["games"]["Hatsune Miku Project Diva Mega Mix+"]["item_name_to_id"]
             self.item_ap_id_to_name = {v: k for k, v in self.item_name_to_ap_id.items()}
 
-            erase_song_list(self.mod_pv_list)
+            if not self.safe_mode:
+                erase_song_list(self.mod_pv_list)
             # If receiving data package, resync previous items
             asyncio.create_task(self.receive_item())
 
@@ -226,8 +227,9 @@ class MegaMixContext(SuperContext):
                 elif network_item.item == 9:
                     Path(self.trapIconLocation).touch()
 
-            for song_pack in ids_to_packs:
-                song_unlock(self.path, ids_to_packs.get(song_pack), False, song_pack)
+            if not self.safe_mode:
+                for song_pack in ids_to_packs:
+                    song_unlock(self.path, ids_to_packs.get(song_pack), False, song_pack)
 
     def check_goal(self):
         if not self.leek_label:
@@ -260,9 +262,9 @@ class MegaMixContext(SuperContext):
                             json_data = load_json_file(file_name)
                             await self.receive_location_check(json_data)
                         except (FileNotFoundError, json.JSONDecodeError) as e:
-                            print(f"Error loading JSON file: {e}")
+                            logger.info(f"Error loading JSON file: {e}")
         except asyncio.CancelledError:
-            print(f"Watch task for {file_name} was canceled.")
+            logger.info(f"Watch task for {file_name} was canceled.")
 
 
     async def watch_death_link_out(self, file_name: str):
@@ -317,6 +319,13 @@ class MegaMixContext(SuperContext):
             if not location_id in self.location_ids:
                 logger.info("No checks to send: Song not in song pool")
                 return
+        elif self.safe_mode and self.safe_mode_strict and self.leeks_obtained < self.leeks_needed:
+            logger.info("Cannot Goal: Leek requirement not met (safe mode)")
+            return
+
+        if self.safe_mode and self.safe_mode_strict and not location_id in {i.item for i in self.items_received}:
+            logger.info(f"No checks to send: Song {self.item_ap_id_to_name[location_id]} has not been received yet (safe mode)")
+            return
 
         if int(song_data.get('scoreGrade')) >= self.grade_needed:
             if location_id == self.goal_id:
@@ -367,6 +376,9 @@ class MegaMixContext(SuperContext):
             logger.info("Auto Remove Set to Off")
 
     async def remove_songs(self):
+        if self.safe_mode:
+            return
+
         missing = {songID // 10 for songID in self.missing_locations}
         finished_songs = {songID for songID in self.checked_locations - self.missing_locations if songID // 10 not in missing}
 
@@ -380,6 +392,10 @@ class MegaMixContext(SuperContext):
         logger.info("Removed songs!")
 
     async def freeplay_toggle(self):
+        if self.safe_mode:
+            logger.warn("Cannot toggle/apply freeplay while safe mode is enabled.")
+            return
+
         self.freeplay = not self.freeplay
 
         received = {recv.item // 10 for recv in self.items_received if recv.item >= 10}
@@ -428,6 +444,21 @@ class MegaMixContext(SuperContext):
         # TODO: The copy of this in on_package should be reworked.
         if self.death_link and not self.watch_death_link_task:
             self.watch_death_link_task = asyncio.create_task(self.watch_death_link_out(self.deathLinkOutLocation))
+
+    async def toggle_safe_mode(self, out_of_logic = ""):
+        self.safe_mode = not self.safe_mode
+
+        if self.safe_mode:
+            self.safe_mode_strict = not bool(out_of_logic)
+
+            if self.server and self.server.socket:
+                await self.restore_songs()
+            logger.info(f"Safe mode enabled. Restart the game if open.\nPrevent out of logic: {self.safe_mode_strict}")
+        else:
+            if self.server and self.server.socket:
+                erase_song_list(self.mod_pv_list)
+                await self.receive_item(0)
+            logger.info("Safe mode disabled. Reload the game via hotkey if open.\nHigher priority mods may override the AP mod.")
 
 
 def launch():

--- a/Client.py
+++ b/Client.py
@@ -453,7 +453,7 @@ class MegaMixContext(SuperContext):
 
             if self.server and self.server.socket:
                 await self.restore_songs()
-            logger.info(f"Safe mode enabled. Restart the game if open.\nPrevent out of logic: {self.safe_mode_strict}")
+            logger.info(f"Safe mode enabled. Restarting the game is recommended.\nPrevent out of logic: {self.safe_mode_strict}")
         else:
             if self.server and self.server.socket:
                 erase_song_list(self.mod_pv_list)

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -98,7 +98,7 @@ Install [ExPatch](#optional-quality-of-life-mods). Modded songs are commonly Ext
 Similar to the [mod's config](#resulting-basic-file-structure), ensure `enabled = true` in a pack's `config.toml`.
 
 ### Songs still aren't appearing
-Run `/restore_songs` in the **Mega Mix Client**, reload, and play manually (honor system).
+Run `/safe_mode` in the **Mega Mix Client** and follow its instructions.
 
 ### Game crashes on entering song list / I'm missing the Archipelago song
 

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -52,7 +52,8 @@ Please read descriptions before installing. These may not be relevant to you or 
 **Note: Currently, using mod songs requires the seed to be [generated locally](/tutorial/Archipelago/setup_en#generating-a-multiplayer-game), not on the website. Hosting on the website afterwards is fine.**
 
 1. Open the **Mega Mix JSON Generator** from the Archipelago Launcher.
-2. Check song packs you would like to appear in your song selection pool. Unchecked packs will remain visible in game unless manually disabled.
+2. Check song packs you would like to appear in your song selection pool.
+   - Unchecked packs will remain visible in game unless manually disabled.
 3. When done checking packs click **Generate Mod String**.
 4. In your YAML on the line for `megamix_mod_data` paste and format it as such:
    - `megamix_mod_data: '{"MyFirstSongPack":[["MyFirstSong",144,224]]}'`
@@ -69,6 +70,8 @@ Individual songs can be excluded from the pool in the YAML's `exclude_songs` sec
 Make sure the **Mega Mix Client** is open and connected to a room.
 
 Play `-Archipelago Randomizer Enabled-`. If a success message does not appear in the **Client** on completion try restarting the **Client**.
+
+If `-Archipelago Randomizer Enabled-` is not on the song list, [fix it.](#game-crashes-on-entering-song-list--im-missing-the-archipelago-song)
 
 ### There are songs outside my specified difficulty settings
 Starting (`start_inventory`), Included (`include_songs`), and the Goal Song (`goal_song`) will *always* ignore difficulty settings.


### PR DESCRIPTION
A more flexible successor to the `/restore_songs` command.

`/restore_songs` issues addressed:
- Only useful after connecting
- The equivalent is ran automatically on goal (in certain conditions) and Client close
- A reconnect was required to undo it (`erase_song_list`)
- Lacks out-of-logic safety
- Song visibility toggling was still happening (ineffective until a reload)
- If the game crashed for whatever reason you're left in the above point's state
- For mods that aren't reload aware, like New Classics, it's easier to not mess with the song list/reload at all