### PR TITLE
Options: improve descriptions, add some examples

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -291,6 +291,8 @@ class MegaMixContext(SuperContext):
         if self.death_link_amnesty_count > self.death_link_amnesty:
             self.death_link_amnesty_count = 0
             await super().send_death(death_text)
+        elif self.death_link_amnesty > 0:
+            logger.info(f"Death Link Amnesty: {self.death_link_amnesty_count} / {self.death_link_amnesty}")
 
 
     def on_deathlink(self, data: dict[str, any]):
@@ -414,14 +416,15 @@ class MegaMixContext(SuperContext):
 
     async def toggle_deathlink(self, amnesty: str = ""):
         if amnesty:
-            if int(amnesty) > -1:
+            if int(amnesty) >= 0:
+                self.death_link_amnesty_count = 0
                 self.death_link_amnesty = int(amnesty)
                 logger.info(f"Death Link Amnesty is now {self.death_link_amnesty}")
             else:
                 logger.info("Death Link Amnesty must be 0 or greater.")
         else:
             self.death_link = not self.death_link
-            logger.info(f"Death Link is now {['off','on'][self.death_link]}")
+            logger.info(f"Death Link is now {['off','on'][self.death_link]} (Amnesty: {self.death_link_amnesty_count} / {self.death_link_amnesty})")
             await self.update_death_link(self.death_link)
 
         # This is for when DL is disabled in the YAML and opted into with the Client.

--- a/Options.py
+++ b/Options.py
@@ -17,6 +17,8 @@ class AdditionalSongs(Range):
     """The total number of songs that will be placed in the randomisation pool.
     - This does not count any Starting Songs or the Goal Song.
     - The final song count may be lower due to other settings.
+
+    Given the large range, "random" is not recommended. If you have a 500+ check seed, this is why.
     """
     range_start = 15
     range_end = 3900
@@ -26,7 +28,7 @@ class AdditionalSongs(Range):
 
 class DuplicateSongPercentage(Range):
     """
-    After placing required items, the percentage of remaining filler slots to become duplicate song items.
+    After placing required items (leeks and songs), the percentage of remaining filler slots to become duplicate song items.
     Duplicate songs are considered Useful thus out of logic and may speed up completion time.
     """
     range_start = 0
@@ -137,10 +139,11 @@ class ScoreGradeNeeded(Choice):
 
 
 class TotalLeeksAvailable(Range):
-    """Controls how many Leeks are added to the pool based on the number of songs, including starting songs.
-    Higher numbers leads to more consistent game lengths, but will cause individual leeks to be less important.
+    """Controls how many Leeks are added to the pool based on the total number of starting and additional songs.
+    A higher available Leek percentage leads to more consistent game lengths, but individual leeks will be less important.
     Range is a percentage.
-    """
+
+    Example: 5 Starting Songs, 40 Additional Songs, 20% Leeks Total = 9 Leeks will be available"""
     range_start = 10
     range_end = 40
     default = 20
@@ -148,7 +151,9 @@ class TotalLeeksAvailable(Range):
 
 
 class LeeksRequiredPercentage(Range):
-    """The percentage of Leeks in the item pool that are needed to unlock the Goal Song."""
+    """The percentage of available Leeks in the item pool that are needed to unlock the Goal Song.
+
+    Example: 5 Starting Songs, 40 Additional Songs, 20% Leeks Total, 80% Leeks Needed = 7 out of 9 Leeks needed to goal"""
     range_start = 50
     range_end = 100
     default = 80
@@ -158,6 +163,7 @@ class LeeksRequiredPercentage(Range):
 class GoalSongs(ItemSet):
     """Guarantee one song listed here as the final Goal Song.
     - Difficulty options are ignored.
+    - If a Goal Song is also in the Starting Inventory, it will not be chosen as a Goal Song.
 
     Use /item_groups in the Client for a list of available song groups."""
     display_name = "Goal Song"

--- a/Options.py
+++ b/Options.py
@@ -19,7 +19,7 @@ class AdditionalSongs(Range):
     - The final song count may be lower due to other settings.
 
     Given the large range, "random" is not recommended. If you have a 500+ check seed, this is why.
-    Assuming a bad case of 5 minutes per song (failing, death link, traps, BK, etc.), expect to clear 12 songs per hour.
+    At a pace of 4 minutes per song (fails, death links, traps, etc.), expect to clear 15 songs/30 checks an hour.
     """
     range_start = 15
     range_end = 3900
@@ -193,7 +193,7 @@ class IncludeSongs(ItemSet):
 
 class ExcludeSongs(ItemSet):
     """Songs listed here and not previously chosen as a Goal or Include will be excluded from being a part of the seed.
-    This is recommended over exclude_locations which instead allows songs to appear but with guaranteed filler checks.
+    This is recommended instead of exclude_locations which would allow songs to appear but with guaranteed filler checks.
 
     Use /item_groups in the Client for a list of available song groups."""
     display_name = "Exclude Songs"

--- a/Options.py
+++ b/Options.py
@@ -193,6 +193,7 @@ class IncludeSongs(ItemSet):
 
 class ExcludeSongs(ItemSet):
     """Songs listed here and not previously chosen as a Goal or Include will be excluded from being a part of the seed.
+    This is recommended over exclude_locations which instead allows songs to appear but with guaranteed filler checks.
 
     Use /item_groups in the Client for a list of available song groups."""
     display_name = "Exclude Songs"

--- a/Options.py
+++ b/Options.py
@@ -29,7 +29,7 @@ class AdditionalSongs(Range):
 
 class DuplicateSongPercentage(Range):
     """
-    After placing required items (leeks and songs), the percentage of remaining filler slots to become duplicate song items.
+    After placing required items (Leeks and songs), the percentage of remaining filler slots to become duplicate song items.
     Duplicate songs are considered Useful thus out of logic and may speed up completion time.
     """
     range_start = 0
@@ -141,7 +141,7 @@ class ScoreGradeNeeded(Choice):
 
 class TotalLeeksAvailable(Range):
     """Controls how many Leeks are added to the pool based on the total number of starting and additional songs.
-    A higher available Leek percentage leads to more consistent game lengths, but individual leeks will be less important.
+    A higher available Leek percentage leads to more consistent game lengths, but individual Leeks will be less important.
     Range is a percentage.
 
     Example: 5 Starting Songs, 40 Additional Songs, 20% Leeks Total = 9 Leeks will be available"""

--- a/Options.py
+++ b/Options.py
@@ -19,6 +19,7 @@ class AdditionalSongs(Range):
     - The final song count may be lower due to other settings.
 
     Given the large range, "random" is not recommended. If you have a 500+ check seed, this is why.
+    Assuming a bad case of 5 minutes per song (failing, death link, traps, BK, etc.), expect to clear 12 songs per hour.
     """
     range_start = 15
     range_end = 3900

--- a/Options.py
+++ b/Options.py
@@ -140,13 +140,16 @@ class ScoreGradeNeeded(Choice):
 
 
 class TotalLeeksAvailable(Range):
-    """Controls how many Leeks are added to the pool based on the total number of starting and additional songs.
+    """The percentage of Leeks to add to the pool based on the total number of Starting and Additional Songs.
     A higher available Leek percentage leads to more consistent game lengths, but individual Leeks will be less important.
-    Range is a percentage.
 
-    Example: 5 Starting Songs, 40 Additional Songs, 20% Leeks Total = 9 Leeks will be available"""
+    Example: (5 Starting + 40 Additional Songs) * 20% Leeks Total = 9 Leeks will be available
+
+    Recommended values are between 10 and 40.
+    WARNING: Higher values, especially 100, are more suited for solo seeds to replicate the console progression experience.
+    """
     range_start = 10
-    range_end = 40
+    range_end = 100
     default = 20
     display_name = "Leek Percentage"
 
@@ -154,7 +157,7 @@ class TotalLeeksAvailable(Range):
 class LeeksRequiredPercentage(Range):
     """The percentage of available Leeks in the item pool that are needed to unlock the Goal Song.
 
-    Example: 5 Starting Songs, 40 Additional Songs, 20% Leeks Total, 80% Leeks Needed = 7 out of 9 Leeks needed to goal"""
+    Example: (5 Starting + 40 Additional Songs) * 20% Leeks Total * 80% Leeks Needed = 7 out of 9 Leeks needed to goal"""
     range_start = 50
     range_end = 100
     default = 80

--- a/Options.py
+++ b/Options.py
@@ -224,7 +224,7 @@ class DeathLinkAmnesty(Range):
     """
     display_name = "Death Link Amnesty"
     range_start = 0
-    range_end = 5
+    range_end = 10
     default = 0
 
 


### PR DESCRIPTION
Especially for song count and win requirements.

`TotalLeeksAvailable`/`leek_count_percentage` maximum raised to 100 for more flexibility in solo seeds.