### PR TITLE
Client: find the mod folder

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -77,7 +77,7 @@ class MegaMixContext(SuperContext):
 
         self.game = "Hatsune Miku Project Diva Mega Mix+"
         self.path = game_paths().get("mods")
-        self.mod_name = "ArchipelagoMod"
+        self.mod_name = game_paths().get("modname")
         self.mod_pv = f"{self.path}/{self.mod_name}/rom/mod_pv_db.txt"
         self.songResultsLocation = f"{self.path}/{self.mod_name}/results.json"
         self.deathLinkInLocation = f"{self.path}/{self.mod_name}/death_link_in"

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -25,6 +25,7 @@ def game_paths() -> dict[str, str]:
     game_path = os.path.dirname(exe_path)
     mods_path = os.path.join(game_path, "mods")
     dlc_path = os.path.join(game_path, "diva_dlc00.cpk")
+    mod_name = "ArchipelagoMod"
 
     # Seemingly no TOML parser in frozen AP
     dml_config = os.path.join(game_path, "config.toml")
@@ -34,10 +35,21 @@ def game_paths() -> dict[str, str]:
             if mod_line:
                 mods_path = os.path.join(game_path, mod_line.group(1))
 
+    # Find the Archipelago mod folder by pv_144.usm
+    # walk in case the mod structure changes in the future
+    folders = {"AP", "rom", "movie"}
+    for root, dirs, files in os.walk(mods_path, topdown=False):
+        dirs[:] = [d for d in dirs if d in folders]
+        if "pv_144.usm" in files:
+            mod = os.path.relpath(root, mods_path)
+            mod_name = mod.split(os.sep)[0]
+            break
+
     return {
         "exe": exe_path,
         "game": game_path,
         "mods": mods_path,
+        "modname": mod_name,
         "dlc": dlc_path,
     }
 

--- a/DataHandler.py
+++ b/DataHandler.py
@@ -35,12 +35,12 @@ def game_paths() -> dict[str, str]:
             if mod_line:
                 mods_path = os.path.join(game_path, mod_line.group(1))
 
-    # Find the Archipelago mod folder by pv_144.usm
+    # Find the Archipelago mod folder by pv_144.dsc
     # walk in case the mod structure changes in the future
-    folders = {"AP", "rom", "movie"}
+    folders = {"AP", "rom", "script"}
     for root, dirs, files in os.walk(mods_path, topdown=False):
         dirs[:] = [d for d in dirs if d in folders]
-        if "pv_144.usm" in files:
+        if "pv_144.dsc" in files:
             mod = os.path.relpath(root, mods_path)
             mod_name = mod.split(os.sep)[0]
             break

--- a/docs/setup_en.md
+++ b/docs/setup_en.md
@@ -32,7 +32,7 @@ Hatsune Miku Project DIVA Mega Mix Plus\
 ├ dinput8.dll       <─ mod loader
 ├ config.toml       <─ mod loader config
 └ mods\
-  └ ArchipelagoMod\ <─ AP mod folder, required to be this name
+  └ ArchipelagoMod\ <─ AP mod folder
     └ config.toml   <─ AP mod config
 ```
 


### PR DESCRIPTION
PR 17 on the mod improves its portability to function with any mod folder name.

This is the other half of that. The Client will now search for the mod folder by `pv_144.dsc` instead of being hardcoded to `HMPDMM+/mods/ArchipelagoMod`.