### PR TITLE
init: fix state leak

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -105,7 +105,7 @@ class MegaMixWorld(World):
         self.starting_songs: list[str] = []
         self.included_songs: list[str] = []
         self.final_song_ids: set[int] = set()
-        self.location_count: int = 0
+        self.location_count: int = 0 # Remove when PR 122 is merged
 
     def generate_early(self):
         re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})

--- a/__init__.py
+++ b/__init__.py
@@ -105,7 +105,6 @@ class MegaMixWorld(World):
         self.starting_songs: list[str] = []
         self.included_songs: list[str] = []
         self.final_song_ids: set[int] = set()
-        self.location_count: int = 0 # Remove when PR 122 is merged
 
     def generate_early(self):
         re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 #AP
 from worlds.AutoWorld import World, WebWorld
 from worlds.LauncherComponents import Component, components, Type, launch_subprocess
-from BaseClasses import Region, Item, ItemClassification, Entrance, Tutorial, MultiWorld
+from BaseClasses import Region, Item, ItemClassification, Tutorial
 from Options import PerGameCommonOptions, OptionError
 import settings
 
@@ -94,17 +94,18 @@ class MegaMixWorld(World):
     location_name_to_id = {name: code for name, code in mm_collection.location_names_to_id.items()}
     item_name_groups = mm_collection.get_item_name_groups()
 
-    # Working Data
-    player_mod_data = {}
-    player_mod_ids = {}
-    player_mod_remap = {}
-    victory_song_name: str = ""
-    victory_song_id: int
-    starting_songs: list[str] = []
-    included_songs: list[str]
-    final_song_ids: set[int] = set()
-    needed_token_count: int
-    location_count: int
+    def __init__(self, multiworld, player):
+        super().__init__(multiworld, player)
+        # Working Data
+        self.player_mod_data = {}
+        self.player_mod_ids = {}
+        self.player_mod_remap = {}
+        self.victory_song_name: str = ""
+        self.victory_song_id: int = 10
+        self.starting_songs: list[str] = []
+        self.included_songs: list[str] = []
+        self.final_song_ids: set[int] = set()
+        self.location_count: int = 0
 
     def generate_early(self):
         re_gen_passthrough = getattr(self.multiworld, "re_gen_passthrough", {})


### PR DESCRIPTION
Passes previously failing hooks:
- Mysteryem/Archipelago-fuzzer/hooks/global_mutation
- Mysteryem/Archipelago-fuzzer/hooks/global_dict_or_list_mutation

`starting_songs`/`included_songs`/`final_song_ids` were the main offenders but now all the would-be instance variables are instanced.

From testing, the biggest cross-player leak was with `final_song_ids` though at worst that would interfere with Universal Tracker. `starting_songs` and `included_songs` are reset in `handle_plando()` early enough to not matter, but would still theoretically leak state.

Remove `location_count` after #122 is merged.