### PR TITLE
Client: watcher improvements

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -253,13 +253,11 @@ class MegaMixContext(SuperContext):
 
         while True:
             await asyncio.sleep(1)
-
             try:
                 modified = os.path.getmtime(file_path)
                 if modified > last_modified:
                     last_modified = modified
                     json_data = load_json_file(file_path)
-
                     await self.receive_location_check(json_data)
             except Exception as e:
                 logger.debug(e)

--- a/Client.py
+++ b/Client.py
@@ -259,8 +259,12 @@ class MegaMixContext(SuperContext):
                     last_modified = modified
                     json_data = load_json_file(file_path)
                     await self.receive_location_check(json_data)
+            except FileNotFoundError as e:
+                if last_modified > 0.0:
+                    logger.debug(f"{e} ({last_modified})")
+                    last_modified = 0.0
             except Exception as e:
-                logger.debug(e)
+                logger.debug(f"{e} ({last_modified})")
 
 
     async def watch_death_link_out(self, file_path: str):

--- a/Client.py
+++ b/Client.py
@@ -114,11 +114,8 @@ class MegaMixContext(SuperContext):
         self.death_link_amnesty = 0
         self.death_link_amnesty_count = 0
 
-        self.watch_task = None
-        if not self.watch_task:
-            self.watch_task = asyncio.create_task(self.watch_json_file(self.songResultsLocation))
-
-        self.watch_death_link_task = None
+        self.watch_task: asyncio.Task[int] | None = None
+        self.watch_death_link_task: asyncio.Task[int] | None = None
 
         self.obtained_items_queue = asyncio.Queue()
         self.critical_section_lock = asyncio.Lock()
@@ -155,6 +152,10 @@ class MegaMixContext(SuperContext):
             self.death_link_amnesty = self.options.get("deathLink_Amnesty", 0)
             self.death_link_amnesty_count = 0
             asyncio.create_task(self.update_death_link(self.death_link))
+
+            # Watcher tasks
+            if not self.watch_task:
+                self.watch_task = asyncio.create_task(self.watch_json_file(self.songResultsLocation))
 
             if self.death_link and not self.watch_death_link_task:
                 self.watch_death_link_task = asyncio.create_task(self.watch_death_link_out(self.deathLinkOutLocation))
@@ -245,31 +246,28 @@ class MegaMixContext(SuperContext):
             song_unlock(self.path, {self.goal_id}, False, song_pack)
 
 
-    async def watch_json_file(self, file_name: str):
+    async def watch_json_file(self, file_path: str):
         """Watch a JSON file for changes and call the callback function."""
-        file_path = os.path.join(os.path.dirname(__file__), file_name)
-        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
-        try:
-            while True:
-                await asyncio.sleep(1)  # Wait for a short duration
-                if os.path.isfile(file_path):
-                    modified = os.path.getmtime(file_path)
-                    if modified > last_modified:
-                        last_modified = modified
-                        try:
-                            json_data = load_json_file(file_name)
-                            await self.receive_location_check(json_data)
-                        except (FileNotFoundError, json.JSONDecodeError) as e:
-                            print(f"Error loading JSON file: {e}")
-        except asyncio.CancelledError:
-            print(f"Watch task for {file_name} was canceled.")
+        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else time.time()
+        logger.debug(f"Watching {file_path} ({last_modified})")
+
+        while True:
+            await asyncio.sleep(1)
+
+            try:
+                modified = os.path.getmtime(file_path)
+                if modified > last_modified:
+                    last_modified = modified
+                    json_data = load_json_file(file_path)
+
+                    await self.receive_location_check(json_data)
+            except Exception as e:
+                logger.debug(e)
 
 
-    async def watch_death_link_out(self, file_name: str):
-        file_path = os.path.join(os.path.dirname(__file__), file_name)
-        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
-
-        logger.debug(f"Watching {self.deathLinkOutLocation} ({last_modified})")
+    async def watch_death_link_out(self, file_path: str):
+        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else time.time()
+        logger.debug(f"Watching {file_path} ({last_modified})")
 
         while True:
             await asyncio.sleep(0.25)

--- a/Client.py
+++ b/Client.py
@@ -249,7 +249,7 @@ class MegaMixContext(SuperContext):
     async def watch_json_file(self, file_path: str):
         """Watch a JSON file for changes and call the callback function."""
         last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
-        logger.info(f"{__name__}: watching {os.path.basename(file_path)} ({last_modified})")
+        logger.info(f"Watching {os.path.basename(file_path)} ({last_modified})")
 
         while True:
             await asyncio.sleep(1)
@@ -269,7 +269,7 @@ class MegaMixContext(SuperContext):
 
     async def watch_death_link_out(self, file_path: str):
         last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
-        logger.info(f"{__name__}: watching {os.path.basename(file_path)} ({last_modified})")
+        logger.info(f"Watching {os.path.basename(file_path)} ({last_modified})")
 
         while True:
             await asyncio.sleep(0.25)

--- a/Client.py
+++ b/Client.py
@@ -249,7 +249,7 @@ class MegaMixContext(SuperContext):
     async def watch_json_file(self, file_path: str):
         """Watch a JSON file for changes and call the callback function."""
         last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
-        logger.debug(f"Watching {file_path} ({last_modified})")
+        logger.info(f"{__name__}: watching {os.path.basename(file_path)} ({last_modified})")
 
         while True:
             await asyncio.sleep(1)
@@ -269,7 +269,7 @@ class MegaMixContext(SuperContext):
 
     async def watch_death_link_out(self, file_path: str):
         last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
-        logger.debug(f"Watching {file_path} ({last_modified})")
+        logger.info(f"{__name__}: watching {os.path.basename(file_path)} ({last_modified})")
 
         while True:
             await asyncio.sleep(0.25)

--- a/Client.py
+++ b/Client.py
@@ -248,7 +248,7 @@ class MegaMixContext(SuperContext):
 
     async def watch_json_file(self, file_path: str):
         """Watch a JSON file for changes and call the callback function."""
-        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else time.time()
+        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
         logger.debug(f"Watching {file_path} ({last_modified})")
 
         while True:
@@ -264,7 +264,7 @@ class MegaMixContext(SuperContext):
 
 
     async def watch_death_link_out(self, file_path: str):
-        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else time.time()
+        last_modified = os.path.getmtime(file_path) if os.path.isfile(file_path) else 0.0
         logger.debug(f"Watching {file_path} ({last_modified})")
 
         while True:


### PR DESCRIPTION
- Start watching after first connect instead of Client start
  - Log `Watching results.json (123.456)` to the Client
- Results watcher is now `while -> try` instead of `try -> while` which could fail once and require a Client restart

---

Previous problem scenario:
 - Fresh mod install, no `results.json`
 - Start Client
 - Something breaks the outer `try`:
   - `results.json` does not exist
   - JSON decode error
   - ...
 - Watcher never tries again without Client restart
