### PR TITLE
init: progHP for UT

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -110,6 +110,8 @@ class MegaMixWorld(World):
         if re_gen_passthrough and self.game in re_gen_passthrough:
             slot_data: dict[str, any] = re_gen_passthrough[self.game]
 
+            self.options.progressive_hp.value = int(slot_data.get("progHP", 0)) + 1
+
             # Inject mod data, remap as needed
             from .SymbolFixer import format_song_name
             from .Items import SongData


### PR DESCRIPTION
Go Mode currently fails gracefully since the prog HP value it uses is `0` so the Leek count rule is enough. However, `Go Mode: Yes` is not logical until all prog HP are received.