### PR TITLE
Options: add start_inventory_from_pool

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -1,5 +1,5 @@
 from Options import Toggle, Range, Choice, DeathLink, ItemSet, OptionSet, PerGameCommonOptions, FreeText, \
-    Visibility, Removed, OptionGroup
+    Visibility, Removed, OptionGroup, StartInventoryPool
 from dataclasses import dataclass
 
 from .MegaMixCollection import MegaMixCollections
@@ -255,7 +255,7 @@ class ProgressiveHP(Range):
     Divide the HP bar into items and start with 1/X HP. The rest go into the item pool.
     - There may be less based on free space after adding Leeks and Songs.
     - Non-lethal Death Link applies to max available HP
-    - For extras use start_inventory
+    - For finer control use "Progressive HP" in start_inventory or start_inventory_from_pool
 
     WARNING: Currently the only logic for this is needing full HP for the Goal Song.
     """
@@ -322,6 +322,7 @@ class MegaMixOptions(PerGameCommonOptions):
     traps_enabled: TrapsEnabled
     trap_percentage: TrapPercentage
     progressive_hp: ProgressiveHP
+    start_inventory_from_pool: StartInventoryPool
 
     # Deprecated
     exclude_singers: Removed

--- a/__init__.py
+++ b/__init__.py
@@ -274,6 +274,10 @@ class MegaMixWorld(World):
         return MegaMixSongItem(name, self.player, song)
 
     def get_filler_item_name(self):
+        traps_enabled = sorted(self.options.traps_enabled.value)
+        if traps_enabled and self.options.trap_percentage > 0:
+            return self.random.choice(traps_enabled)
+
         return self.mm_collection.FILLER_NAME
 
     def create_items(self) -> None:

--- a/__init__.py
+++ b/__init__.py
@@ -273,6 +273,9 @@ class MegaMixWorld(World):
         self.final_song_ids.add(song.songID)
         return MegaMixSongItem(name, self.player, song)
 
+    def get_filler_item_name(self):
+        return self.mm_collection.FILLER_NAME
+
     def create_items(self) -> None:
         items_left = len(self.multiworld.get_unfilled_locations(self.player))
 


### PR DESCRIPTION
Add `start_inventory_from_pool` support which allows finer control of Progressive HP.
```Py
progressive_hp: 20 # 20 segments, 19 provided by the itempool

start_inventory:
# Start the seed at 25% HP (1+4/20), but there are still 19 (4 extra) in the pool for flexibility
 - Progressive HP: 4 

# vs

start_inventory_from_pool:
# Start the seed at 25% HP and pulling from the 19 with no extras, they are replaced with SAFEs or traps (if enabled)
 - Progressive HP: 4 
```