### PR TITLE
Client: Switch to hp.txt

### DIFF
--- a/Client.py
+++ b/Client.py
@@ -76,7 +76,7 @@ class MegaMixContext(SuperContext):
         self.trapHiddenLocation = f"{self.path}/{self.mod_name}/hidden"
         self.trapIconLocation = f"{self.path}/{self.mod_name}/icontrap"
         self.songListLocation = f"{self.path}/{self.mod_name}/song_list.txt"
-        self.progHPLocation = f"{self.path}/{self.mod_name}/hp"
+        self.progHPLocation = f"{self.path}/{self.mod_name}/hp.txt"
         self.modData = None
         self.modded = False
         self.freeplay = False
@@ -412,7 +412,7 @@ class MegaMixContext(SuperContext):
 
     async def cleanup(self):
         clean = [self.trapIconLocation, self.trapHiddenLocation, self.trapSuddenLocation,
-                 self.songListLocation, self.deathLinkInLocation, self.progHPLocation]
+                 self.songListLocation, self.deathLinkInLocation, self.progHPLocation, f"{self.path}/{self.mod_name}/hp"]
 
         for file in clean:
             if Path(file).exists():


### PR DESCRIPTION
Companion to https://github.com/Cynichill/Diva-Archipelago-Mod/pull/19 which switches from `hp` to `hp.txt` for easier editing by players (if needed)

Mod#19 includes fallback to check for `hp.txt` then `hp`. The Client will only write to `hp.txt` but will delete it and `hp` on close.