### PR TITLE
init: deprio leeks

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -30,7 +30,7 @@ class AdditionalSongs(Range):
 class DuplicateSongPercentage(Range):
     """
     After placing required items (Leeks and songs), the percentage of remaining filler slots to become duplicate song items.
-    Duplicate songs are considered Useful thus out of logic and may speed up completion time.
+    Duplicate songs are progressive like their original but classified as Useful thus out of logic and may speed up completion time.
     """
     range_start = 0
     range_end = 100

--- a/__init__.py
+++ b/__init__.py
@@ -245,7 +245,7 @@ class MegaMixWorld(World):
     def create_item(self, name: str) -> Item:
 
         if name == self.mm_collection.LEEK_NAME:
-            return MegaMixFixedItem(name, ItemClassification.progression_skip_balancing, self.mm_collection.LEEK_CODE, self.player)
+            return MegaMixFixedItem(name, ItemClassification.progression_deprioritized_skip_balancing, self.mm_collection.LEEK_CODE, self.player)
 
         elif name == self.mm_collection.FILLER_NAME:
             return MegaMixFixedItem(name, ItemClassification.filler, self.mm_collection.FILLER_CODE, self.player)


### PR DESCRIPTION
Since most YAMLs are likely to have an excess this prevents Leeks from taking a lot of priority locations by default.

Songs and Prog HP left alone.