### PR TITLE
init: Alternative Goal Mode

### DIFF
--- a/Options.py
+++ b/Options.py
@@ -108,8 +108,19 @@ class ScoreGradeNeeded(Choice):
     default = 2
 
 
+class GoalMode(Choice):
+    """How the Goal Song is unlocked.
+
+    Leeks: The original mode where you collect Leeks from the item pool.
+    Percent: Reach a percentage of checks done. More room in the item pool for other things.
+    """
+    display_name = "Goal Mode"
+    option_Leeks = 0
+    option_Percentage = 1
+
+
 class TotalLeeksAvailable(Range):
-    """The percentage of Leeks to add to the pool based on the total number of Starting and Additional Songs.
+    """If Goal Mode is Leeks, the percentage of Leeks to add to the pool based on the total number of Starting and Additional Songs.
     A higher available Leek percentage leads to more consistent game lengths, but individual Leeks will be less important.
 
     Example: (5 Starting + 40 Additional Songs) * 20% Leeks Total = 9 Leeks will be available
@@ -124,13 +135,24 @@ class TotalLeeksAvailable(Range):
 
 
 class LeeksRequiredPercentage(Range):
-    """The percentage of available Leeks in the item pool that are needed to unlock the Goal Song.
+    """If Goal Mode is Leeks, the percentage of available Leeks in the item pool that are needed to unlock the Goal Song.
 
     Example: (5 Starting + 40 Additional Songs) * 20% Leeks Total * 80% Leeks Needed = 7 out of 9 Leeks needed to goal"""
     range_start = 50
     range_end = 100
     default = 80
     display_name = "Leek Percentage Needed to Win"
+
+
+class GoalPercentage(Range):
+    """If Goal Mode is Percentage, the percentage of checks done to unlock the Goal Song.
+    - Highly influenced by rooms that use collect or send_location.
+    - It is recommended to have little to no Duplicate Songs.
+    """
+    display_name = "Goal Percentage"
+    range_start = 35
+    range_end = 100
+    default = 39
 
 
 class GoalSongs(ItemSet):
@@ -219,6 +241,8 @@ megamix_option_groups = [
         StartingSongs,
         AdditionalSongs,
         DuplicateSongPercentage,
+        GoalMode,
+        GoalPercentage,
         TotalLeeksAvailable,
         LeeksRequiredPercentage,
     ]),
@@ -256,8 +280,10 @@ class MegaMixOptions(PerGameCommonOptions):
     song_difficulty_rating_min: DifficultyRatingMin
     song_difficulty_rating_max: DifficultyRatingMax
     grade_needed: ScoreGradeNeeded
+    goal_mode: GoalMode
     leek_count_percentage: TotalLeeksAvailable
     leek_win_count_percentage: LeeksRequiredPercentage
+    goal_percentage: GoalPercentage
     goal_song: GoalSongs
     include_songs_percentage: IncludeSongsPercentage
     include_songs: IncludeSongs

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ from worlds.LauncherComponents import Component, components, Type, launch_subpro
 from BaseClasses import Region, Item, ItemClassification, Tutorial
 from Options import PerGameCommonOptions, OptionError
 import settings
-from rule_builder.rules import Has
+from rule_builder.rules import Has, HasFromListUnique
 
 #Local
 from .Options import MegaMixOptions, megamix_option_groups
@@ -273,12 +273,14 @@ class MegaMixWorld(World):
 
         items_left = len(self.multiworld.get_unfilled_locations(self.player))
 
-        for _ in range(0, self.get_leek_count()):
-            self.multiworld.itempool.append(self.create_item(self.mm_collection.LEEK_NAME))
+        if self.options.goal_mode.value == self.options.goal_mode.option_Leeks:
+            for _ in range(0, self.get_leek_count()):
+                self.multiworld.itempool.append(self.create_item(self.mm_collection.LEEK_NAME))
+            items_left -= self.get_leek_count()
 
         self.multiworld.itempool.extend(self.create_item(song) for song in self.included_songs)
 
-        items_left -= self.get_leek_count() + len(self.included_songs)
+        items_left -= len(self.included_songs)
         if items_left <= 0:
             return
 
@@ -326,10 +328,17 @@ class MegaMixWorld(World):
                 menu_region.locations.append(loc)
 
     def set_rules(self) -> None:
-        self.set_completion_rule(
-            Has(self.mm_collection.LEEK_NAME, self.get_leek_win_count())
-            & Has("Progressive HP", self.prog_hp_added)
-        )
+        goal = Has("Progressive HP", self.prog_hp_added)
+
+        match self.options.goal_mode.value:
+            case self.options.goal_mode.option_Leeks:
+                goal &= Has(self.mm_collection.LEEK_NAME, self.get_leek_win_count())
+
+            case self.options.goal_mode.option_Percentage:
+                goal &= HasFromListUnique(*self.included_songs,
+                                          count=len(self.included_songs) * self.options.goal_percentage.value // 100)
+
+        self.set_completion_rule(goal)
 
     def get_leek_count(self) -> int:
         """Number of Leeks to be placed in the item pool based on user option and final song count."""
@@ -370,10 +379,13 @@ class MegaMixWorld(World):
         return slot_data
 
     def fill_slot_data(self):
+        goalCondition = self.get_leek_win_count() #if self.options.goal_mode.value == self.se
+
         return {
             "victoryID": self.victory_song_id,
             "finalSongIDs": self.final_song_ids,
-            "leekWinCount": self.get_leek_win_count(),
+            "goalMode": self.options.goal_mode.value,
+            "goalCondition": goalCondition,
             "scoreGradeNeeded": self.options.grade_needed.value,
             "death_link": True, # APCpp requires this key name to set the tag
             "modData": {pack: [[song[0], song[1]] for song in songs if song[1] in self.final_song_ids]

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -167,3 +167,13 @@ class TestOptionNoDLC(MegaMixTestBase):
         dlc = {song for song in pool if self.world.mm_collection.song_items.get(song).DLC}
 
         self.assertEqual(0, len(dlc), f"DLC is disabled, got {len(dlc)} in the item pool.")
+
+
+class TestGoalModes(MegaMixTestBase):
+    options = {
+        "goal_mode": "percentage"
+    }
+
+    def test_no_leeks(self):
+        leeks = sum(1 for item in self.world.multiworld.itempool if item.code == self.world.mm_collection.LEEK_CODE)
+        self.assertEqual(0, leeks, f"Percentage Goal Mode should have 0 leeks, got {leeks}.")


### PR DESCRIPTION
Needs mod support before real testing.

Instead of a McGuffin hunt, the percentage of checks done is used to unlock the goal. No Leeks are added to the itempool. This is highly susceptible to rooms that use collect and similar features.

(As of 6c8a35b319045910aa880a59b0aa28768f11ab9e) The slot data change will break back-compat with old generations.
Slot data *could* be built conditionally, only having the needed goal key and value `leekWinCount: 5`/`WinPercent: 39` to stay back-compat.

- [ ] Universal Tracker support
