### PR TITLE
MMC/DH: Song/pack skip marker

### DIFF
--- a/DataHandler.py
+++ b/DataHandler.py
@@ -104,7 +104,8 @@ def get_player_specific_ids(mod_data: str, remap: dict[int, dict[str, list]]) ->
     try:
         parsed = json.loads(mod_data)
         mod_json_schema.validate(parsed)
-        player_specific = {song[1]: song[0] for pack, songs in parsed.items() for song in songs}
+        player_specific = {song[1]: song[0] for pack, songs in parsed.items() for song in songs
+                           if not pack.startswith("#SKIP#") and not song[0].startswith("#SKIP#")}
     except SchemaError as e:
         raise OptionError(f"Failed to extract player specific IDs (schema)\n{e}")
     except Exception as e: # JSONDecodeError, UnicodeDecodeError

--- a/MegaMixCollection.py
+++ b/MegaMixCollection.py
@@ -55,14 +55,14 @@ class MegaMixCollections:
                             not isinstance(song, list)
                             or not list(map(type, song)) == [str, int, int]
                             or song[1] <= 0 or song[2] <= 0
+                            or song[1] in base_game_ids
+                            or pack.startswith("#SKIP#") # user-defined skip without regenerating the string
+                            or song[0].startswith("#SKIP#") # user-defined skip without regenerating the string
                         ):
-                            logger.warning(f"Skipping {pack} {song}")
+                            logger.debug(f"Skipping {pack} {song}")
                             continue
 
                         song_id = song[1]
-
-                        if song_id in base_game_ids:
-                            continue
 
                         song_name = format_song_name(song[0], song_id)
                         item_id = (song_id * 10)


### PR DESCRIPTION
Allows adding `#SKIP#` to the start of a pack or song name to prevent MMC from creating it for the datapackage. This allows temporary, targeted exclusions without regenerating or making heavy modifications to the mod string.

Potential issues:
 - ~~Player A skips, Player B doesn't, improve player-specific IDs~~ Done, but no feedback
 - Skipped items are used elsewhere in the YAML, like `include_songs`, that now fail because they don't exist
   -  Always create in MMC with marker removed?